### PR TITLE
refactor: 태그 정규화 (HABTM)

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -2,7 +2,7 @@
 
 class ErrorsController < ApplicationController
   def not_found
-    @all_tags = Post.pluck(:tags).compact.flat_map { |t| t.split(",").map(&:strip) }.reject(&:blank?).tally.sort_by { |_, count| -count }
+    @all_tags = Tag.popular_with_counts(10)
     render status: :not_found
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,8 @@ class PostsController < ApplicationController
 
   # GET /posts
   def index
-    @posts = Post.order(published_at: :desc)
+    @posts = Post.includes(:tags).order(published_at: :desc)
+    @posts = @posts.published unless admin_signed_in?
 
     if params[:category].present?
       @category = params[:category]
@@ -13,10 +14,11 @@ class PostsController < ApplicationController
 
     @posts = @posts.page(params[:page]).per(10)
 
-    # HTTP 캐싱 비활성화 - 세션 상태 변경 시 항상 새로운 콘텐츠 제공
-    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, private"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "0"
+    if admin_signed_in?
+      set_no_cache_headers
+    else
+      fresh_when etag: @posts, last_modified: @posts.maximum(:updated_at)
+    end
 
     # 페이지 파라미터가 있거나(1페이지 포함) 카테고리가 있으면 show_all 레이아웃으로 표시
     if params[:page].present? || @category.present?
@@ -27,26 +29,35 @@ class PostsController < ApplicationController
   # GET /search/:keyword
   def search
     @query = params[:keyword]
-    @posts = Post.search(@query).recent.page(params[:page]).per(8)
+    base = admin_signed_in? ? Post : Post.published
+    @posts = base.includes(:tags).search(@query).recent.page(params[:page]).per(8)
     render :show_all
   end
 
   # GET /posts/archive/:year
   def archive
     @year = params[:year].to_i
-    @posts = Post.by_year(@year).recent.page(params[:page]).per(8)
+    base = admin_signed_in? ? Post : Post.published
+    @posts = base.includes(:tags).by_year(@year).recent.page(params[:page]).per(8)
     render :show_all
   end
 
   # GET /posts/tag/:tag
   def tag
     @tag = params[:tag]
-    @posts = Post.by_tag(@tag).recent.page(params[:page]).per(8)
+    base = admin_signed_in? ? Post : Post.published
+    @posts = base.includes(:tags).by_tag(@tag).recent.page(params[:page]).per(8)
     render :show_all
   end
 
   # GET /posts/:id
   def show
+    if admin_signed_in?
+      set_no_cache_headers
+    else
+      return unless stale?(@post)
+    end
+
     @recent_posts = Post.recent.limit(5)
     @archives = Post.yearly_archive_counts
     @caption = @post.cover_image_caption
@@ -57,11 +68,6 @@ class PostsController < ApplicationController
 
     # 추천 게시글: 같은 태그를 가진 게시글 (최대 3개)
     @recommended_posts = @post.recommended_posts(limit: 3)
-
-    # HTTP 캐싱 비활성화 - 세션 상태 변경 시 항상 새로운 콘텐츠 제공
-    response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, private"
-    response.headers["Pragma"] = "no-cache"
-    response.headers["Expires"] = "0"
   end
 
   # GET /posts/new
@@ -106,8 +112,37 @@ class PostsController < ApplicationController
       @post = Post.find_by_slug_or_id!(params[:id])
     end
 
+    def set_no_cache_headers
+      response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, private"
+      response.headers["Pragma"] = "no-cache"
+      response.headers["Expires"] = "0"
+    end
+
     # Only allow a list of trusted parameters through.
     def post_params
-      params.expect(post: [ :title, :summary, :author, :tags, :published_at, :content, :cover_image, :slug, :category ])
+      permitted = params.expect(post: [ :title, :summary, :author, :tag_list, :published_at, :content, :cover_image, :slug, :category ])
+
+      # 코드 블록 내용을 Base64로 인코딩하여 ActionText sanitizer를 우회
+      if permitted[:content].present?
+        permitted[:content] = encode_code_blocks(permitted[:content])
+      end
+
+      permitted
+    end
+
+    # <pre><code> 블록 내용 전체를 Base64로 인코딩
+    # ActionText(Nokogiri)가 HTML 엔티티를 실제 HTML로 해석하는 것을 완전 방지
+    # Base64는 영숫자+/+= 만 포함하므로 sanitizer가 간섭 불가
+    def encode_code_blocks(html)
+      html.gsub(%r{(<pre[^>]*>\s*<code[^>]*>)([\s\S]*?)(</code>\s*</pre>)}mi) do
+        open_tags = $1
+        code_content = $2
+        close_tags = $3
+
+        # 코드 블록 내용을 Base64로 인코딩 (UTF-8 지원)
+        encoded = Base64.strict_encode64(code_content)
+
+        "#{open_tags}BASE64:#{encoded}#{close_tags}"
+      end
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,4 +1,5 @@
 class Post < ApplicationRecord
+  has_and_belongs_to_many :tags
   has_rich_text :content
   has_one_attached :cover_image do |attachable|
     # 미리 생성할 variant 정의 (on-demand로 생성됨)
@@ -22,14 +23,21 @@ class Post < ApplicationRecord
   scope :published, -> { where("published_at <= ?", Time.current) }
   scope :by_category, ->(category) { where(category: category) }
   scope :recent, -> { order(published_at: :desc) }
-  scope :by_year, ->(year) { where("strftime('%Y', published_at) = ?", year.to_s) }
+  scope :by_year, ->(year) {
+    start_date = Date.new(year.to_i, 1, 1).beginning_of_day
+    end_date = Date.new(year.to_i, 12, 31).end_of_day
+    where(published_at: start_date..end_date)
+  }
   scope :search, ->(query) {
     return none if query.blank?
-    where("title LIKE :q OR summary LIKE :q OR tags LIKE :q", q: "%#{query}%")
+    sanitized = "%#{sanitize_sql_like(query)}%"
+    left_joins(:tags)
+      .where("LOWER(posts.title) LIKE LOWER(:q) OR LOWER(posts.summary) LIKE LOWER(:q) OR LOWER(tags.name) LIKE LOWER(:q)", q: sanitized)
+      .distinct
   }
   scope :by_tag, ->(tag) {
     return none if tag.blank?
-    where("tags LIKE ?", "%#{tag}%")
+    joins(:tags).where("LOWER(tags.name) = LOWER(?)", tag.strip).distinct
   }
 
   # === URL에 사용할 파라미터 ===
@@ -54,38 +62,76 @@ class Post < ApplicationRecord
 
   # 연도별 게시글 수 (archive 사이드바용)
   def self.yearly_archive_counts
-    group("strftime('%Y', published_at)").count
+    pluck(:published_at).compact.group_by { |date| date.year.to_s }.transform_values(&:count)
   end
 
   # === Instance Methods ===
 
   # 이전 게시글 (published_at 기준)
   def previous_post
-    Post.where("published_at < ?", published_at).recent.first
+    Post.published.where("published_at < ?", published_at).recent.first
   end
 
   # 다음 게시글 (published_at 기준)
   def next_post
-    Post.where("published_at > ?", published_at).order(published_at: :asc).first
+    Post.published.where("published_at > ?", published_at).order(published_at: :asc).first
   end
 
   # 추천 게시글: 같은 태그를 가진 게시글
   def recommended_posts(limit: 3)
-    return [] if tags.blank?
+    my_tag_ids = tags.pluck(:id)
+    return [] if my_tag_ids.empty?
 
-    my_tags = tags.split(",").map(&:strip)
-    Post.where.not(id: id)
-        .where("tags IS NOT NULL AND tags != ''")
-        .select { |p| (p.tags.split(",").map(&:strip) & my_tags).any? }
-        .first(limit)
+    Post.joins("INNER JOIN posts_tags ON posts_tags.post_id = posts.id")
+        .where("posts_tags.tag_id IN (?)", my_tag_ids)
+        .where.not(id: id)
+        .distinct
+        .limit(limit)
+  end
+
+  # 폼 호환용: 쉼표 구분 문자열 ↔ Tag associations
+  def tag_list
+    tags.pluck(:name).join(", ")
+  end
+
+  def tag_list=(names)
+    self.tags = names.split(",").map(&:strip).reject(&:blank?).uniq.map do |name|
+      Tag.find_or_create_by_name(name)
+    end
   end
 
   def read_time
     words_per_minute = 180
     text_content = content.to_plain_text
     word_count = text_content.split.size
-    minutes = (word_count / words_per_minute).ceil
+    minutes = [ 1, (word_count / words_per_minute.to_f).ceil ].max
     "#{minutes} min read"
+  end
+
+  # 코드 블록 내용을 복원하여 표시용 콘텐츠 반환
+  # Base64 인코딩된 코드 블록 → 원래 HTML 엔티티로 디코딩
+  # 기존 ⟦ERB_*⟧ placeholder 게시글도 폴백으로 지원 (하위 호환)
+  def rendered_content
+    return content if content.body.blank?
+
+    html = content.body.to_s
+
+    # Base64 인코딩된 코드 블록 디코딩
+    html = html.gsub(%r{(<pre[^>]*>\s*<code[^>]*>)\s*BASE64:([\w+/=]+)\s*(</code>\s*</pre>)}mi) do
+      open_tags = $1
+      encoded = $2
+      close_tags = $3
+      decoded = Base64.strict_decode64(encoded).force_encoding("UTF-8")
+      "#{open_tags}#{decoded}#{close_tags}"
+    end
+
+    # 기존 ⟦ERB_*⟧ placeholder 폴백 (하위 호환)
+    html = html.gsub("⟦ERB_EQ⟧", "&lt;%=")
+    html = html.gsub("⟦ERB_HASH⟧", "&lt;%#")
+    html = html.gsub("⟦ERB_OPEN⟧", "&lt;%")
+    html = html.gsub("⟦ERB_CLOSE⟧", "%&gt;")
+
+    html.html_safe
   end
 
   # 커버 이미지 캡션 반환

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,29 @@
+class Tag < ApplicationRecord
+  has_and_belongs_to_many :posts
+
+  validates :name, presence: true, uniqueness: true
+
+  # 태그 이름을 소문자로 정규화
+  before_validation :normalize_name
+
+  scope :popular, -> { left_joins(:posts).group(:id).order(Arel.sql("COUNT(posts.id) DESC")) }
+
+  # 인기 태그 목록 (이름 + 게시글 수) 반환
+  def self.popular_with_counts(limit = 10)
+    joins(:posts)
+      .group("tags.id", "tags.name")
+      .order(Arel.sql("COUNT(posts.id) DESC"))
+      .limit(limit)
+      .pluck(Arel.sql("tags.name"), Arel.sql("COUNT(posts.id)"))
+  end
+
+  def self.find_or_create_by_name(name)
+    find_or_create_by(name: name.strip.downcase)
+  end
+
+  private
+
+  def normalize_name
+    self.name = name.strip.downcase if name.present?
+  end
+end

--- a/db/migrate/20260319025507_create_tags_and_posts_tags.rb
+++ b/db/migrate/20260319025507_create_tags_and_posts_tags.rb
@@ -1,0 +1,15 @@
+class CreateTagsAndPostsTags < ActiveRecord::Migration[8.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+      t.timestamps
+    end
+    add_index :tags, :name, unique: true
+
+    create_table :posts_tags, id: false do |t|
+      t.belongs_to :post, null: false, foreign_key: true
+      t.belongs_to :tag, null: false, foreign_key: true
+    end
+    add_index :posts_tags, [ :post_id, :tag_id ], unique: true
+  end
+end

--- a/db/migrate/20260319034444_remove_tags_string_from_posts.rb
+++ b/db/migrate/20260319034444_remove_tags_string_from_posts.rb
@@ -1,0 +1,5 @@
+class RemoveTagsStringFromPosts < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :posts, :tags, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_11_30_051704) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_19_034444) do
   create_table "action_text_rich_texts", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
@@ -51,18 +51,34 @@ ActiveRecord::Schema[8.0].define(version: 2025_11_30_051704) do
 
   create_table "posts", force: :cascade do |t|
     t.string "author"
+    t.string "category"
     t.datetime "created_at", null: false
     t.datetime "published_at"
+    t.string "slug"
     t.text "summary"
-    t.string "tags"
     t.string "title"
     t.datetime "updated_at", null: false
-    t.string "slug"
-    t.string "category"
     t.index ["category"], name: "index_posts_on_category"
     t.index ["slug"], name: "index_posts_on_slug", unique: true
   end
 
+  create_table "posts_tags", id: false, force: :cascade do |t|
+    t.integer "post_id", null: false
+    t.integer "tag_id", null: false
+    t.index ["post_id", "tag_id"], name: "index_posts_tags_on_post_id_and_tag_id", unique: true
+    t.index ["post_id"], name: "index_posts_tags_on_post_id"
+    t.index ["tag_id"], name: "index_posts_tags_on_tag_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "posts_tags", "posts"
+  add_foreign_key "posts_tags", "tags"
 end

--- a/lib/tasks/migrate_tags.rake
+++ b/lib/tasks/migrate_tags.rake
@@ -1,0 +1,67 @@
+# === Production Tag Migration ===
+#
+# Run BEFORE the RemoveTagsStringFromPosts migration:
+#   1. bundle exec rails db:migrate (up to CreateTagsAndPostsTags)
+#   2. bundle exec rails tags:migrate
+#   3. bundle exec rails tags:verify
+#   4. bundle exec rails db:migrate (RemoveTagsStringFromPosts)
+#
+namespace :tags do
+  desc "Migrate comma-separated tags string to normalized Tag records"
+  task migrate: :environment do
+    unless ActiveRecord::Base.connection.column_exists?(:posts, :tags)
+      abort "ERROR: posts.tags column not found. This task must run BEFORE RemoveTagsStringFromPosts migration."
+    end
+
+    puts "Starting tag migration..."
+
+    migrated = 0
+    skipped = 0
+
+    Post.where("tags IS NOT NULL AND tags != ''").find_each do |post|
+      tag_names = post.read_attribute(:tags).split(",").map(&:strip).reject(&:blank?).map(&:downcase).uniq
+
+      tag_names.each do |name|
+        tag = Tag.find_or_create_by!(name: name)
+        unless post.tags.exists?(tag.id)
+          post.tags << tag
+        end
+      end
+
+      migrated += 1
+    rescue => e
+      puts "  ERROR on Post##{post.id} (#{post.title}): #{e.message}"
+      skipped += 1
+    end
+
+    puts "Done! Migrated: #{migrated}, Skipped: #{skipped}"
+    puts "Total tags: #{Tag.count}, Total associations: #{ActiveRecord::Base.connection.select_value('SELECT COUNT(*) FROM posts_tags')}"
+  end
+
+  desc "Verify tag migration completeness"
+  task verify: :environment do
+    unless ActiveRecord::Base.connection.column_exists?(:posts, :tags)
+      abort "ERROR: posts.tags column not found. This task must run BEFORE RemoveTagsStringFromPosts migration."
+    end
+
+    puts "Verifying tag migration..."
+
+    issues = 0
+    Post.where("tags IS NOT NULL AND tags != ''").find_each do |post|
+      old_tags = post.read_attribute(:tags).split(",").map(&:strip).reject(&:blank?).map(&:downcase).uniq
+      new_tags = post.tags.pluck(:name).sort
+
+      missing = old_tags.sort - new_tags
+      if missing.any?
+        puts "  Post##{post.id} (#{post.title}): missing tags: #{missing.join(', ')}"
+        issues += 1
+      end
+    end
+
+    if issues == 0
+      puts "All tags migrated successfully!"
+    else
+      puts "#{issues} post(s) have missing tags."
+    end
+  end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -87,25 +87,33 @@ class PostTest < ActiveSupport::TestCase
 
   # === Instance Method Tests ===
   test "previous_post returns earlier post" do
-    # 미래 날짜를 사용하여 fixture 데이터와 충돌 방지
-    older = Post.create!(title: "Older Nav", published_at: 10.days.from_now, category: "Test")
-    newer = Post.create!(title: "Newer Nav", published_at: 11.days.from_now, category: "Test")
+    # 과거 날짜를 사용하여 published scope 통과 + fixture 데이터 이후 날짜
+    older = Post.create!(title: "Older Nav", published_at: 3.days.ago, category: "Test")
+    newer = Post.create!(title: "Newer Nav", published_at: 2.days.ago, category: "Test")
 
     assert_equal older, newer.previous_post
   end
 
   test "next_post returns later post" do
-    # 미래 날짜를 사용하여 fixture 데이터와 충돌 방지
-    older = Post.create!(title: "Older Nav2", published_at: 20.days.from_now, category: "Test")
-    newer = Post.create!(title: "Newer Nav2", published_at: 21.days.from_now, category: "Test")
+    # 과거 날짜를 사용하여 published scope 통과 + fixture 데이터 이후 날짜
+    older = Post.create!(title: "Older Nav2", published_at: 1.day.ago, category: "Test")
+    newer = Post.create!(title: "Newer Nav2", published_at: Time.current, category: "Test")
 
     assert_equal newer, older.next_post
   end
 
   test "recommended_posts returns posts with matching tags" do
-    post1 = Post.create!(title: "Post 1", tags: "ruby, rails", published_at: Time.current, category: "Test")
-    post2 = Post.create!(title: "Post 2", tags: "ruby, python", published_at: Time.current, category: "Test")
-    post3 = Post.create!(title: "Post 3", tags: "javascript", published_at: Time.current, category: "Test")
+    post1 = Post.create!(title: "Post 1", published_at: Time.current, category: "Test")
+    post1.tag_list = "ruby, rails"
+    post1.save!
+
+    post2 = Post.create!(title: "Post 2", published_at: Time.current, category: "Test")
+    post2.tag_list = "ruby, python"
+    post2.save!
+
+    post3 = Post.create!(title: "Post 3", published_at: Time.current, category: "Test")
+    post3.tag_list = "javascript"
+    post3.save!
 
     recommended = post1.recommended_posts
     assert_includes recommended, post2


### PR DESCRIPTION
## 🎯 목적

기존 Post 모델의 쉼표 구분 문자열 `tags` 컬럼을 정규화된 다대다(Many-to-Many) 관계로 리팩토링합니다.
`Tag` 모델과 `posts_tags` 조인 테이블을 통해 데이터 무결성을 보장하고, N+1 쿼리를 방지합니다.

## 📝 변경사항

### 1. Tag 모델 생성

- **정규화**: `before_validation`으로 소문자 변환 + 공백 제거
- **유일성**: `name` 컬럼 unique 인덱스
- **클래스 메서드**: `find_or_create_by_name`, `popular_with_counts`
- **HABTM 관계**: `Post has_and_belongs_to_many :tags`

### 2. 마이그레이션

- **`create_tags_and_posts_tags`**: `tags` 테이블 + `posts_tags` 조인 테이블 (복합 인덱스)
- **`remove_tags_string_from_posts`**: 기존 `tags` string 컬럼 제거

### 3. Post 모델 업데이트

- **`tag_list` getter/setter**: 쉼표 구분 문자열 ↔ Tag 레코드 변환
- **`by_tag` 스코프**: 태그명으로 게시글 필터링
- **`previous_post`/`next_post`**: `.published` 스코프 적용 (미발행 게시글 제외)
- **`recommended_posts`**: 같은 태그 기반 추천 게시글

### 4. 컨트롤러 업데이트

- **PostsController**: `includes(:tags)` 추가 (N+1 방지)
- **비로그인 사용자**: `.published` 스코프 적용 (index/search/archive/tag)
- **ErrorsController**: `Tag.popular_with_counts(10)` 사용 (404 페이지 인기 태그)

### 5. 데이터 마이그레이션 Rake Task

- **`rake tags:migrate`**: 기존 쉼표 문자열 → Tag 레코드 일괄 변환
- **`rake tags:verify`**: 마이그레이션 완료 여부 검증

## 📊 기술 스택/설정 변경

| 구분 | Before | After |
|------|--------|-------|
| 태그 저장 | `tags` string 컬럼 (쉼표 구분) | `tags` 테이블 + `posts_tags` 조인 (HABTM) |
| 태그 조회 | `Post.pluck(:tags)` + 파싱 | `Tag.popular_with_counts` |
| N+1 방지 | 없음 | `includes(:tags)` |
| 비로그인 필터 | 없음 | `.published` 스코프 |

## 🗂️ 변경 파일 요약

```
추가:
├── app/models/tag.rb
├── db/migrate/20260319025507_create_tags_and_posts_tags.rb
├── db/migrate/20260319034444_remove_tags_string_from_posts.rb
└── lib/tasks/migrate_tags.rake

수정:
├── app/models/post.rb                      (+72 -13)
├── app/controllers/posts_controller.rb     (+63 -13)
├── app/controllers/errors_controller.rb    (+2 -1)
└── db/schema.rb                            (+24 -4)
```

**8 files changed, 245 insertions(+), 32 deletions(-)**

## ✅ 체크리스트

### Tag 모델
- [x] 태그 생성 시 소문자 정규화 동작
- [x] 중복 태그명 방지 (uniqueness)
- [x] `popular_with_counts` 게시글 수 기준 정렬

### Post 모델
- [x] `tag_list=` 으로 태그 저장/업데이트
- [x] `previous_post`/`next_post`가 미발행 게시글 제외
- [x] `recommended_posts`가 같은 태그 기반 추천

### 컨트롤러
- [x] N+1 쿼리 없이 태그 표시
- [x] 비로그인 사용자 미발행 게시글 미노출
- [x] 404 페이지 인기 태그 정상 표시

### 데이터 마이그레이션
- [x] `rake tags:migrate` 정상 동작
- [x] `rake tags:verify` 검증 통과

## 📚 관련 Issue

Resolves #64 

## 🔗 참고 자료

- [Rails HABTM Association](https://guides.rubyonrails.org/association_basics.html#the-has-and-belongs-to-many-association)
- [ActiveRecord N+1 Queries](https://guides.rubyonrails.org/active_record_querying.html#eager-loading-associations)