### PR TITLE
chore: SimpleCov 도입 — 병렬 테스트 호환 및 그룹/필터 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@
 # Personal Files
 /personal/*
 /docs/*
+
+# SimpleCov 커버리지 산출물
+/coverage/
+
+# 외부 AI 스킬 카탈로그 (로컬 참고용)
+/skills/

--- a/Gemfile
+++ b/Gemfile
@@ -79,4 +79,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  # Code coverage measurement
+  gem "simplecov", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,7 @@ GEM
     debug (1.11.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    docile (1.4.1)
     dotenv (3.2.0)
     dotenv-rails (3.2.0)
       dotenv (= 3.2.0)
@@ -339,6 +340,12 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -434,6 +441,7 @@ DEPENDENCIES
   rails-i18n (~> 8.1.0)
   rubocop-rails-omakase
   selenium-webdriver
+  simplecov
   solid_cable
   solid_cache
   solid_queue

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,21 @@
+require "simplecov"
+SimpleCov.start "rails" do
+  enable_coverage :branch
+
+  add_filter "/test/"
+  add_filter "/config/"
+  add_filter "/db/"
+  add_filter "/vendor/"
+  add_filter "/bin/"
+
+  add_group "Controllers", "app/controllers"
+  add_group "Models",      "app/models"
+  add_group "Helpers",     "app/helpers"
+  add_group "Jobs",        "app/jobs"
+  add_group "Mailers",     "app/mailers"
+  add_group "Channels",    "app/channels"
+end
+
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
@@ -7,9 +25,27 @@ module ActiveSupport
     # Run tests in parallel with specified workers
     parallelize(workers: :number_of_processors)
 
+    # SimpleCov parallel-test compatibility:
+    # fork된 각 워커에 고유한 command_name을 부여하여 결과 덮어쓰기 방지.
+    parallelize_setup do |worker|
+      SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"
+    end
+
+    # 각 워커 종료 시 결과를 기록하여 SimpleCov가 자동 병합하도록 트리거.
+    parallelize_teardown do |_worker|
+      SimpleCov.result
+    end
+
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     fixtures :all
 
     # Add more helper methods to be used by all tests here...
+
+    # Helper: sign in as admin for controller tests.
+    # 사용 예정: uploads_controller_test, 관리자 전용 posts 액션 테스트 등.
+    def sign_in_as_admin
+      admin = admins(:one)
+      post login_url, params: { email: admin.email, password: "password" }
+    end
   end
 end


### PR DESCRIPTION
## 🎯 목적

테스트 커버리지 측정 인프라(SimpleCov)를 도입하여 장기적으로 **테스트 커버리지 100% 추적**을 가능하게 하는 사전 준비를 수행합니다.
이번 PR은 **인프라 세팅**에 한정하며, 누락 컨트롤러/헬퍼/잡/메일러 테스트 작성 및 `minimum_coverage` 임계값 상승은 후속 반복 작업에서 다룹니다.
Rails 8의 병렬 테스트(`parallelize`)와 호환되도록 SimpleCov 공식 권장 패턴을 적용합니다.

## 📝 변경사항

### 1. SimpleCov Gem 도입

- **`:test` 그룹에 추가**: `gem "simplecov", require: false`
- **버전**: `simplecov (0.22.0)` (의존성 `docile`, `simplecov-html`, `simplecov_json_formatter` 포함)
- **브랜치 커버리지 활성화**: `enable_coverage :branch`
- **Rails 프로파일**: `SimpleCov.start "rails"`

### 2. 필터 · 그룹 정리

- **필터**: `/test/`, `/config/`, `/db/`, `/vendor/`, `/bin/`
- **그룹**: `Controllers`, `Models`, `Helpers`, `Jobs`, `Mailers`, `Channels` — HTML 리포트 가독성 향상

### 3. 병렬 테스트 호환 처리

- **`parallelize_setup`**: fork된 각 워커에 `SimpleCov.command_name "#{SimpleCov.command_name}-#{worker}"`를 부여하여 결과 덮어쓰기 방지
- **`parallelize_teardown`**: 각 워커 종료 시 `SimpleCov.result`를 호출하여 병합 트리거
- **자동 병합**: SimpleCov 0.18+의 `use_merging` 기본 동작으로 결과 자동 병합
- **현재 동작**: 테스트 개수가 Rails 기본 병렬 임계값(50) 이하일 때는 단일 프로세스로 실행되며, 이 경우 호환 블록은 무해 (테스트가 늘어나 병렬이 활성화되면 자동 적용)

### 4. `sign_in_as_admin` 테스트 헬퍼

- **위치**: `test/test_helper.rb`의 `ActiveSupport::TestCase`
- **용도**: 관리자 전용 경로(`uploads_controller`, 관리자 Post 액션 등) 테스트에서 로그인 상태 재사용
- **용도 주석**: 후속 테스트 작성자를 위한 안내 주석 포함

### 5. `.gitignore` 보강

- **`/coverage/`**: SimpleCov 산출물(HTML 리포트, `.resultset.json`) 트래킹 제외
- **`/skills/`**: 로컬 AI 스킬 카탈로그 참고용 저장소 (Push 대상 아님)

## 📊 기술 스택/설정 변경

| 구분 | Before | After |
|------|--------|-------|
| 테스트 커버리지 도구 | 없음 | SimpleCov 0.22.0 (branch coverage) |
| 병렬 테스트 호환 | 결과 병합 미처리 | `parallelize_setup/teardown`으로 워커별 `command_name` 분리 |
| 리포트 구조 | 단일 파일 목록 | Controllers / Models / Helpers / Jobs / Mailers / Channels 그룹핑 |
| 커버리지 산출물 관리 | 트래킹 위험 | `/coverage/` gitignore 처리 |
| 로컬 참고 자료 관리 | `/skills/` 트래킹 위험 | `/skills/` gitignore 처리 |

## 🗂️ 변경 파일 요약

```
수정:
├── Gemfile
├── Gemfile.lock
├── test/test_helper.rb
└── .gitignore
```

## ✅ 체크리스트

### Gem / 설정

- [x] `Gemfile` `:test` 그룹에 `simplecov` 추가
- [x] `Gemfile.lock` 동기화 (`simplecov 0.22.0` 및 의존성)
- [x] `SimpleCov.start "rails"` 블록에 branch coverage / 필터 / 그룹 구성

### 병렬 테스트 호환

- [x] `parallelize_setup`에서 `command_name` 분리
- [x] `parallelize_teardown`에서 `SimpleCov.result` 호출

### 테스트 헬퍼

- [x] `sign_in_as_admin` 헬퍼 (용도 주석 포함)

### Git 관리

- [x] `.gitignore`에 `/coverage/` 추가
- [x] `.gitignore`에 `/skills/` 추가

### 로컬 검증

- [x] `bundle install` 성공
- [x] `bin/rails test` 통과 (50 runs / 95 assertions / 0 failures)
- [x] `coverage/index.html` 생성 및 그룹 섹션 정상 표시
- [x] Line 51.22% / Branch 54.44% — 기준점(51.21% / 54.44%) 대비 ±1%p 이내 재현

## 📚 관련 Issue

Resolves #102 

## 🔗 참고 자료

- [SimpleCov README — Parallel tests](https://github.com/simplecov-ruby/simplecov#parallel-tests)
- [Rails Guides — Testing Rails Applications: Parallel Testing](https://guides.rubyonrails.org/testing.html#parallel-testing)

## 🗒️ 후속 작업 (별도 Issue/PR 예정)

- `uploads_controller_test.rb` 작성 (사전 준비물 `sign_in_as_admin` + `test/fixtures/files/test_image.jpg` 활용)
- `thumbnails_controller_test.rb` 작성
- `errors_controller_test.rb` 커버리지 보완
- `image_helper_test.rb` 작성
- `application_job` / `application_mailer` 기본 테스트
- `tag_test.rb` resultset 누락 원인 조사
- `SimpleCov.minimum_coverage` 단계적 상승 (60 → 75 → 90 → 100)