### PR TITLE
chore: 지식 그래프 커밋 및 CLAUDE.md 최신화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@
 
 # 외부 AI 스킬 카탈로그 (로컬 참고용)
 /skills/
+
+# Understand-Anything 지식 그래프
+# knowledge-graph.json 등 본체는 커밋한다 — 한 번 올려두면 다른 환경에서
+# 분석 파이프라인을 다시 돌리지 않아도 된다.
+# 아래는 실행할 때마다 새로 생기는 로컬 산출물이라 제외한다.
+/.ua/intermediate/
+/.ua/diff-overlay.json
+/.ua/.trash-*/

--- a/.ua/.understandignore
+++ b/.ua/.understandignore
@@ -1,0 +1,81 @@
+# .understandignore — patterns for files/dirs to exclude from analysis
+# Syntax: same as .gitignore (globs, # comments, ! negation, trailing / for dirs)
+# Lines below are suggestions — uncomment to activate.
+# Use ! prefix to force-include something excluded by defaults.
+#
+# Built-in defaults (always excluded unless negated):
+#   node_modules/, .git/, dist/, build/, obj/, *.lock, *.min.js, etc.
+#
+
+# --- From .gitignore (uncomment to exclude) ---
+
+/.bundle
+/.env*
+/log/*
+/tmp/*
+/storage/*
+/public/assets
+/config/*.key
+/app/assets/builds/*
+/coverage/
+vendor/
+# 분석 도구 자체 산출물 — 프로젝트 소스가 아니므로 그래프에서 제외한다.
+.ua/
+# /personal/*
+# /docs/*
+# /skills/
+
+# --- Detected directories (uncomment to exclude) ---
+
+# test/
+
+# --- Test file patterns (uncomment to exclude) ---
+
+# JS / TS
+# *.test.*
+# *.spec.*
+# *.snap
+# C# / .NET
+# **/*Tests.cs
+# **/*Test.cs
+# **/*Fixture.cs
+# **/*.Tests.csproj
+# Java / Kotlin
+# **/src/test/**
+# **/*Test.java
+# **/*IT.java
+# **/*Spec.kt
+# Go
+# **/*_test.go
+# C++
+# **/*_test.cc
+# **/*_test.cpp
+# **/*_test.cxx
+# **/*Test.cc
+# **/*Test.cpp
+# **/*_unittest.cc
+# **/*_unittest.cpp
+# **/*_browsertest.cc
+# **/*_benchmark.cc
+# **/*Benchmark.cpp
+# Python
+# **/test_*.py
+# **/*_test.py
+# **/tests.py
+# **/conftest.py
+# Rust
+# **/tests.rs
+# **/test_*.rs
+# **/*_test.rs
+# **/bench_*.rs
+# **/*_bench.rs
+# Ruby
+# **/*_spec.rb
+# **/*_test.rb
+# **/test_*.rb
+# **/spec_helper.rb
+# **/test_helper.rb
+# **/rails_helper.rb
+# Swift
+# **/Tests/**/*.swift
+# **/Specs/**/*.swift

--- a/.ua/config.json
+++ b/.ua/config.json
@@ -1,0 +1,3 @@
+{
+  "outputLanguage": "ko"
+}

--- a/.ua/fingerprints.json
+++ b/.ua/fingerprints.json
@@ -1,0 +1,2820 @@
+{
+  "version": "1.0.0",
+  "gitCommitHash": "f970d0e415dd1cf628297524f798dd7c433230de",
+  "generatedAt": "2026-08-01T10:14:01.595Z",
+  "files": {
+    ".dockerignore": {
+      "filePath": ".dockerignore",
+      "contentHash": "70a7387d6d99a8fe06a771a2ccecc2694cfbfe720c1a28c8b0392d4b72d1705e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 52,
+      "hasStructuralAnalysis": false
+    },
+    ".gitattributes": {
+      "filePath": ".gitattributes",
+      "contentHash": "002cee769356794268645fef7b98fef17706af82bbed067b97d203444cb89f0d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": false
+    },
+    ".github/dependabot.yml": {
+      "filePath": ".github/dependabot.yml",
+      "contentHash": "30452891f92d2312a4f8eb9eb16f3932245222c448d99c1d0228d1bd6f6cdb28",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 13,
+      "hasStructuralAnalysis": true
+    },
+    ".github/workflows/ci.yml": {
+      "filePath": ".github/workflows/ci.yml",
+      "contentHash": "781cde542c2019a037e527c8675d7dfe0451e89498f48a2a6a4a086a9c695006",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 105,
+      "hasStructuralAnalysis": true
+    },
+    ".kamal/hooks/docker-setup.sample": {
+      "filePath": ".kamal/hooks/docker-setup.sample",
+      "contentHash": "70e52ccba04b0b8d99517e73fbdd167149113bf94732af0419d81584e99cfc88",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 4,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/post-app-boot.sample": {
+      "filePath": ".kamal/hooks/post-app-boot.sample",
+      "contentHash": "b0b621995f20a44643ee5da40e329cae8a4b947fb20fe17b0159ebbbc2e738d6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 4,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/post-deploy.sample": {
+      "filePath": ".kamal/hooks/post-deploy.sample",
+      "contentHash": "fdaf8360710c8493f8bb4f949f094b3e99c77881c23ce4d2ed9fa1d9df66fc36",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/post-proxy-reboot.sample": {
+      "filePath": ".kamal/hooks/post-proxy-reboot.sample",
+      "contentHash": "a5c808cb346134cd564f048d04bde11425a923c198b7739ed1aab2660fbc6831",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 4,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/pre-app-boot.sample": {
+      "filePath": ".kamal/hooks/pre-app-boot.sample",
+      "contentHash": "fe9f00f8ce30a7b2caa2c5c336b75bbe9973eca58fc2d1f25199cdbae819cc9b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 4,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/pre-build.sample": {
+      "filePath": ".kamal/hooks/pre-build.sample",
+      "contentHash": "f34022a731dc4377784b1198fea70286a199801c78d127b4e1b554f625820b78",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 52,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/pre-connect.sample": {
+      "filePath": ".kamal/hooks/pre-connect.sample",
+      "contentHash": "cc9367b2512b7637704de8d123c229993f594d1dbf95f0e2953659deab729150",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 48,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/pre-deploy.sample": {
+      "filePath": ".kamal/hooks/pre-deploy.sample",
+      "contentHash": "e234139637a828afe3c7efe1d7f3a1eeb7187a38cb8203b82ab2b8d8ca3fec34",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 123,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/hooks/pre-proxy-reboot.sample": {
+      "filePath": ".kamal/hooks/pre-proxy-reboot.sample",
+      "contentHash": "ed473bb8d046cc14f2da7315fc1b5aa538b4666340b99f2def072312f3931503",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 4,
+      "hasStructuralAnalysis": false
+    },
+    ".kamal/secrets": {
+      "filePath": ".kamal/secrets",
+      "contentHash": "67325e6cc9625d8b45388a0f7cf818bd180789af3487ff3aea9ee77c4a6b4107",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 30,
+      "hasStructuralAnalysis": false
+    },
+    ".rubocop.yml": {
+      "filePath": ".rubocop.yml",
+      "contentHash": "86cb7c2ecf4755789497ce5942816dc96fa1298ee509edec3c5f4ebca11bfbd0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 9,
+      "hasStructuralAnalysis": true
+    },
+    ".ruby-version": {
+      "filePath": ".ruby-version",
+      "contentHash": "e216936881cf70499888c8169b6c9925d2d2ff824458c336cf9d058a89c1bac5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "CLAUDE.md": {
+      "filePath": "CLAUDE.md",
+      "contentHash": "4fd051a5b1328d4209d295ca9697019bda4996f8a6e4148cc1f2aa693c74b7e8",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 85,
+      "hasStructuralAnalysis": true
+    },
+    "Dockerfile": {
+      "filePath": "Dockerfile",
+      "contentHash": "f6b242d39b15fe81c5f81b9abce0225c59ea854ce996830943295dec2b0fb8cd",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 79,
+      "hasStructuralAnalysis": true
+    },
+    "Gemfile": {
+      "filePath": "Gemfile",
+      "contentHash": "434c9a37f6babb8459b23bcf37e8834bab54b9f5898adecfeeac28414921120d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 89,
+      "hasStructuralAnalysis": false
+    },
+    "Procfile.dev": {
+      "filePath": "Procfile.dev",
+      "contentHash": "6ce61f352053b48db306a38a997e07a087a91d6e28dfb9c38218d452b710fcdc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "README.md": {
+      "filePath": "README.md",
+      "contentHash": "676a90c44388f6a6fd993b52ff5f192828cdc213f6122b495af90b6e3216a6ea",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 180,
+      "hasStructuralAnalysis": true
+    },
+    "Rakefile": {
+      "filePath": "Rakefile",
+      "contentHash": "480894efa76250e783bb958034eb09a12cfc81da41ffbc30ba2aa7a5872807b4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 7,
+      "hasStructuralAnalysis": false
+    },
+    "app/assets/images/.keep": {
+      "filePath": "app/assets/images/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "app/assets/stylesheets/site.css": {
+      "filePath": "app/assets/stylesheets/site.css",
+      "contentHash": "a03da3fbbde14b80699ca32d240b71f75a93416074420b19d468acc104907f90",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 6175,
+      "hasStructuralAnalysis": false
+    },
+    "app/controllers/application_controller.rb": {
+      "filePath": "app/controllers/application_controller.rb",
+      "contentHash": "09493efcd197a0ac32cb752da43614b1a0918ffb9b3ec57e6ff9094aacb49927",
+      "functions": [
+        {
+          "name": "set_no_transform_cache_control",
+          "params": [],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "admin_signed_in?",
+          "params": [],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "authenticate_admin!",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        }
+      ],
+      "classes": [
+        {
+          "name": "ApplicationController",
+          "methods": [
+            "set_no_transform_cache_control",
+            "admin_signed_in?",
+            "authenticate_admin!"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 53
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ApplicationController"
+      ],
+      "totalLines": 54,
+      "hasStructuralAnalysis": true
+    },
+    "app/controllers/concerns/.keep": {
+      "filePath": "app/controllers/concerns/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "app/controllers/errors_controller.rb": {
+      "filePath": "app/controllers/errors_controller.rb",
+      "contentHash": "a136c87706f70bf86197b173aab58032f41152d2c3492ebff5463aae9736eb28",
+      "functions": [
+        {
+          "name": "not_found",
+          "params": [],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "unprocessable",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "internal_server",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "ErrorsController",
+          "methods": [
+            "not_found",
+            "unprocessable",
+            "internal_server"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 14
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ErrorsController"
+      ],
+      "totalLines": 17,
+      "hasStructuralAnalysis": true
+    },
+    "app/controllers/posts_controller.rb": {
+      "filePath": "app/controllers/posts_controller.rb",
+      "contentHash": "63b179d3713b3bbad517004e97094be0a1f76400f43919d88cb7cc696287cf0f",
+      "functions": [
+        {
+          "name": "index",
+          "params": [],
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "search",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "archive",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "tag",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "show",
+          "params": [],
+          "exported": false,
+          "lineCount": 18
+        },
+        {
+          "name": "new",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "edit",
+          "params": [],
+          "exported": false,
+          "lineCount": 2
+        },
+        {
+          "name": "create",
+          "params": [],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "update",
+          "params": [],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "destroy",
+          "params": [],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "set_post",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "post_scope",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "listing_scope",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "set_no_cache_headers",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "post_params",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        },
+        {
+          "name": "encode_code_blocks",
+          "params": [
+            "html"
+          ],
+          "exported": false,
+          "lineCount": 12
+        }
+      ],
+      "classes": [
+        {
+          "name": "PostsController",
+          "methods": [
+            "index",
+            "search",
+            "archive",
+            "tag",
+            "show",
+            "new",
+            "edit",
+            "create",
+            "update",
+            "destroy",
+            "set_post",
+            "post_scope",
+            "listing_scope",
+            "set_no_cache_headers",
+            "post_params",
+            "encode_code_blocks"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 167
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "PostsController"
+      ],
+      "totalLines": 168,
+      "hasStructuralAnalysis": true
+    },
+    "app/controllers/sessions_controller.rb": {
+      "filePath": "app/controllers/sessions_controller.rb",
+      "contentHash": "a96852dfbcec31aa9c1bfd0a7b41eb19c38085ef331ccc482049086dde2bb097",
+      "functions": [
+        {
+          "name": "new",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "create",
+          "params": [],
+          "exported": false,
+          "lineCount": 15
+        },
+        {
+          "name": "destroy",
+          "params": [],
+          "exported": false,
+          "lineCount": 4
+        },
+        {
+          "name": "reject_when_throttled",
+          "params": [],
+          "exported": false,
+          "lineCount": 6
+        },
+        {
+          "name": "throttle_key",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "failed_attempts",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "record_failed_attempt",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "clear_failed_attempts",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "SessionsController",
+          "methods": [
+            "new",
+            "create",
+            "destroy",
+            "reject_when_throttled",
+            "throttle_key",
+            "failed_attempts",
+            "record_failed_attempt",
+            "clear_failed_attempts"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 74
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "SessionsController"
+      ],
+      "totalLines": 77,
+      "hasStructuralAnalysis": true
+    },
+    "app/controllers/uploads_controller.rb": {
+      "filePath": "app/controllers/uploads_controller.rb",
+      "contentHash": "1ade4bc4316a6f5d3e040e69e85dacb41b0d1e980af7d87df49a5db945e09e1f",
+      "functions": [
+        {
+          "name": "image",
+          "params": [],
+          "exported": false,
+          "lineCount": 63
+        },
+        {
+          "name": "destroy_image",
+          "params": [],
+          "exported": false,
+          "lineCount": 20
+        }
+      ],
+      "classes": [
+        {
+          "name": "UploadsController",
+          "methods": [
+            "image",
+            "destroy_image"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 95
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "UploadsController"
+      ],
+      "totalLines": 100,
+      "hasStructuralAnalysis": true
+    },
+    "app/helpers/application_helper.rb": {
+      "filePath": "app/helpers/application_helper.rb",
+      "contentHash": "a6432111ce6275f1bb9d37fd6e3d8744411bec3cfdeb47c145732d45205f234e",
+      "functions": [
+        {
+          "name": "require_content_libraries",
+          "params": [
+            "*libraries"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "content_library?",
+          "params": [
+            "library"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "content_libraries_for",
+          "params": [
+            "html"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "math_delimiters?",
+          "params": [
+            "html"
+          ],
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "ApplicationHelper",
+          "methods": [
+            "require_content_libraries",
+            "content_library?",
+            "content_libraries_for",
+            "math_delimiters?"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 34
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ApplicationHelper"
+      ],
+      "totalLines": 35,
+      "hasStructuralAnalysis": true
+    },
+    "app/helpers/image_helper.rb": {
+      "filePath": "app/helpers/image_helper.rb",
+      "contentHash": "95d09c78e2b5db8873827d5d66a45ba8695427290f3cb1fcd71e4ad30439a295",
+      "functions": [
+        {
+          "name": "optimized_image_tag",
+          "params": [
+            "attachment",
+            "**options"
+          ],
+          "exported": false,
+          "lineCount": 28
+        },
+        {
+          "name": "responsive_image_tag",
+          "params": [
+            "source",
+            "**options"
+          ],
+          "exported": false,
+          "lineCount": 45
+        },
+        {
+          "name": "picture_tag",
+          "params": [
+            "attachment",
+            "**options"
+          ],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "intrinsic_dimensions",
+          "params": [
+            "attachment"
+          ],
+          "exported": false,
+          "lineCount": 15
+        }
+      ],
+      "classes": [
+        {
+          "name": "ImageHelper",
+          "methods": [
+            "optimized_image_tag",
+            "responsive_image_tag",
+            "picture_tag",
+            "intrinsic_dimensions"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 153
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ImageHelper"
+      ],
+      "totalLines": 156,
+      "hasStructuralAnalysis": true
+    },
+    "app/helpers/posts_helper.rb": {
+      "filePath": "app/helpers/posts_helper.rb",
+      "contentHash": "953aa03fcd62025bf607c29a8a34f87b0882b09624458f6edd10b2cc6372f2f7",
+      "functions": [],
+      "classes": [
+        {
+          "name": "PostsHelper",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 2
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "PostsHelper"
+      ],
+      "totalLines": 3,
+      "hasStructuralAnalysis": true
+    },
+    "app/javascript/application.js": {
+      "filePath": "app/javascript/application.js",
+      "contentHash": "f09f39a77543cc014af0f3c6cd181db882eb5032f484b88ef9c682c547561228",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@hotwired/turbo-rails",
+          "specifiers": []
+        },
+        {
+          "source": "controllers",
+          "specifiers": []
+        },
+        {
+          "source": "init",
+          "specifiers": []
+        }
+      ],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "app/javascript/controllers/application.js": {
+      "filePath": "app/javascript/controllers/application.js",
+      "contentHash": "bd316d985f1cef3633dafd928bae33b599e7ca6353b30777c933e0ed10cfc2ed",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@hotwired/stimulus",
+          "specifiers": [
+            "Application"
+          ]
+        }
+      ],
+      "exports": [
+        "application"
+      ],
+      "totalLines": 10,
+      "hasStructuralAnalysis": true
+    },
+    "app/javascript/controllers/index.js": {
+      "filePath": "app/javascript/controllers/index.js",
+      "contentHash": "fd70b0cc4067227e4319714be1f77a3b075bc112ac140da0cc49b777477c49dc",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "controllers/application",
+          "specifiers": [
+            "application"
+          ]
+        },
+        {
+          "source": "@hotwired/stimulus-loading",
+          "specifiers": [
+            "eagerLoadControllersFrom"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "app/javascript/controllers/search_controller.js": {
+      "filePath": "app/javascript/controllers/search_controller.js",
+      "contentHash": "25f923a11db24c6300afae7b244ff535720b1c01679214ebdd9157f3c88d7347",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "@hotwired/stimulus",
+          "specifiers": [
+            "Controller"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 73,
+      "hasStructuralAnalysis": true
+    },
+    "app/javascript/init.js": {
+      "filePath": "app/javascript/init.js",
+      "contentHash": "e460b4c83d140c65a99fa50599681df52392e33e45672bae2424f2fbe1d4efd9",
+      "functions": [
+        {
+          "name": "decodeBase64CodeBlock",
+          "params": [
+            "encoded"
+          ],
+          "exported": false,
+          "lineCount": 17
+        },
+        {
+          "name": "encodeRawHtmlForTinyMCE",
+          "params": [
+            "raw"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "decodeLegacyErbPlaceholders",
+          "params": [
+            "codeContent"
+          ],
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "initTinyMCE",
+          "params": [],
+          "exported": false,
+          "lineCount": 237
+        },
+        {
+          "name": "handleSearchSubmit",
+          "params": [
+            "event"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "handleCopyLink",
+          "params": [
+            "event"
+          ],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "initializePage",
+          "params": [],
+          "exported": false,
+          "lineCount": 49
+        }
+      ],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 423,
+      "hasStructuralAnalysis": true
+    },
+    "app/jobs/application_job.rb": {
+      "filePath": "app/jobs/application_job.rb",
+      "contentHash": "13c5bcd3f749cbbceeb6412545ea0f6610407f39f9915e4a86f8ff4ded46e563",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ApplicationJob",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ApplicationJob"
+      ],
+      "totalLines": 8,
+      "hasStructuralAnalysis": true
+    },
+    "app/mailers/application_mailer.rb": {
+      "filePath": "app/mailers/application_mailer.rb",
+      "contentHash": "4752aebb60054c79345c6ce39b3430d3c6525842bc291b37d6f051880b6634f8",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ApplicationMailer",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 4
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ApplicationMailer"
+      ],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "app/models/admin.rb": {
+      "filePath": "app/models/admin.rb",
+      "contentHash": "8c9f70639e2770faf1df0ce8674f777e038cd53564a07c6e423839722d7b774a",
+      "functions": [],
+      "classes": [
+        {
+          "name": "Admin",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 9
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "Admin"
+      ],
+      "totalLines": 12,
+      "hasStructuralAnalysis": true
+    },
+    "app/models/application_record.rb": {
+      "filePath": "app/models/application_record.rb",
+      "contentHash": "99c3903a5324009bd797ff179342542e17bfdffa73a651c1a5dfcb78d528f8dd",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ApplicationRecord",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 3
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "ApplicationRecord"
+      ],
+      "totalLines": 4,
+      "hasStructuralAnalysis": true
+    },
+    "app/models/concerns/.keep": {
+      "filePath": "app/models/concerns/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "app/models/post.rb": {
+      "filePath": "app/models/post.rb",
+      "contentHash": "8390164f06ec98cf6f7643f30dd36d333f1862f39593e0078a1e658cc84d8557",
+      "functions": [
+        {
+          "name": "to_param",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "self.find_by_slug_or_id",
+          "params": [
+            "param"
+          ],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "self.find_by_slug_or_id!",
+          "params": [
+            "param"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "self.yearly_archive_counts",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "previous_post",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "next_post",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "recommended_posts",
+          "params": [],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "tag_list",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "tag_list=",
+          "params": [
+            "names"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "read_time",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "rendered_content",
+          "params": [],
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "cover_image_caption",
+          "params": [],
+          "exported": false,
+          "lineCount": 5
+        },
+        {
+          "name": "sync_word_count",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "generate_slug",
+          "params": [],
+          "exported": false,
+          "lineCount": 9
+        }
+      ],
+      "classes": [
+        {
+          "name": "Post",
+          "methods": [
+            "to_param",
+            "self.find_by_slug_or_id",
+            "self.find_by_slug_or_id!",
+            "self.yearly_archive_counts",
+            "previous_post",
+            "next_post",
+            "recommended_posts",
+            "tag_list",
+            "tag_list=",
+            "read_time",
+            "rendered_content",
+            "cover_image_caption",
+            "sync_word_count",
+            "generate_slug"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 192
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "Post"
+      ],
+      "totalLines": 193,
+      "hasStructuralAnalysis": true
+    },
+    "app/models/tag.rb": {
+      "filePath": "app/models/tag.rb",
+      "contentHash": "362328a395964b2082acc5d6d7682cfc01079ba3a9874765b917636ab542c6c3",
+      "functions": [
+        {
+          "name": "self.popular_with_counts",
+          "params": [
+            "limit"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "self.find_or_create_by_name",
+          "params": [
+            "name"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "normalize_name",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "Tag",
+          "methods": [
+            "self.popular_with_counts",
+            "self.find_or_create_by_name",
+            "normalize_name"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 29
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "Tag"
+      ],
+      "totalLines": 30,
+      "hasStructuralAnalysis": true
+    },
+    "app/views/active_storage/blobs/_blob.html.erb": {
+      "filePath": "app/views/active_storage/blobs/_blob.html.erb",
+      "contentHash": "f389a156e8704ee8d35aa58dbefd3e0257f235e630a7090c4d17dd05aad598ff",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/errors/internal_server.html.erb": {
+      "filePath": "app/views/errors/internal_server.html.erb",
+      "contentHash": "37ba04060960377b65f5db71845ed69e9b9b4f9bcf69a94b4ca54b7192bbe67b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/errors/not_found.html.erb": {
+      "filePath": "app/views/errors/not_found.html.erb",
+      "contentHash": "90230f7ab0c5676cb73347eccd94c0dad41da87b4a147e284eb18babf2dddda3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/errors/unprocessable.html.erb": {
+      "filePath": "app/views/errors/unprocessable.html.erb",
+      "contentHash": "be17c53cfef74f0904faed23df2ccb10a42490b787d9005d4d4d20d359d29f19",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/kaminari/_gap.html.erb": {
+      "filePath": "app/views/kaminari/_gap.html.erb",
+      "contentHash": "9ca454ed35bea570456848d73c65eeb293187317e8179cb17ed221b451f4d407",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 9,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/kaminari/_next_page.html.erb": {
+      "filePath": "app/views/kaminari/_next_page.html.erb",
+      "contentHash": "eefd8fe2cf6e5841e2a1abe95dcd80a6e91cb2d45f2734ee8cc0ddfda390bb7c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/kaminari/_page.html.erb": {
+      "filePath": "app/views/kaminari/_page.html.erb",
+      "contentHash": "0eba7ab2915373448ef7a349a81a39b723dcf4367a7dda0c7e614a2693fa6cc9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/kaminari/_paginator.html.erb": {
+      "filePath": "app/views/kaminari/_paginator.html.erb",
+      "contentHash": "e1592c503cadb480c55aff573726f0d7025739956b2459a5656fe3d4d8930ecc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 29,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/kaminari/_prev_page.html.erb": {
+      "filePath": "app/views/kaminari/_prev_page.html.erb",
+      "contentHash": "b44c540b6d820c9c5c5fefb84c4c09ab63e3813f07fefa095ead4dfe26d89dae",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 21,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/layouts/action_text/contents/_content.html.erb": {
+      "filePath": "app/views/layouts/action_text/contents/_content.html.erb",
+      "contentHash": "af61b8c14053c29fba0aeaf9ea9afc014332cfa4d1f4a4b2bafcbb84aa8e48e2",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/layouts/application.html.erb": {
+      "filePath": "app/views/layouts/application.html.erb",
+      "contentHash": "3815308b9b773a78fd6b58d860fd5c816c982e802adf7955bb81cebeda4a33de",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 641,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/layouts/mailer.html.erb": {
+      "filePath": "app/views/layouts/mailer.html.erb",
+      "contentHash": "cb817d2717f100add8c62ed77a37fdf3af5c0bd73c80b445bf815c200370e407",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 14,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/layouts/mailer.text.erb": {
+      "filePath": "app/views/layouts/mailer.text.erb",
+      "contentHash": "9c6055817eeee9a1e6a3baff4670ccd7f1a081f88e1c4a648be9a02efcfb275e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_form.html.erb": {
+      "filePath": "app/views/posts/_form.html.erb",
+      "contentHash": "d1167fc5964118a5c088f9e023ae6e50b02837763610559e57efc6e1008de147",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 97,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_post.html.erb": {
+      "filePath": "app/views/posts/_post.html.erb",
+      "contentHash": "92f83d63001307defdcfaf5d0accc3a71f7093cea87ce9a5295aaa38128ae267",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_post_card.html.erb": {
+      "filePath": "app/views/posts/_post_card.html.erb",
+      "contentHash": "cc65ba79a76f6709c9a3a1ed7cd48b29316412b9f866e3a89c3a87bff9d69d07",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 24,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_post_meta.html.erb": {
+      "filePath": "app/views/posts/_post_meta.html.erb",
+      "contentHash": "3b61c31776b120064abc013ff32dbdee226938fbc714d87bad9c8d24ec532939",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 12,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_post_navigation.html.erb": {
+      "filePath": "app/views/posts/_post_navigation.html.erb",
+      "contentHash": "a4d11e16fa003289a83af84c8fb722ed37640818f0c8f27b4509f1c2fe1a8e2e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 27,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_recommended_posts.html.erb": {
+      "filePath": "app/views/posts/_recommended_posts.html.erb",
+      "contentHash": "d7d60ab663eb887146467538760849fdf14194d3934d59998c575c2d0ea5efcf",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 38,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/_sidebar.html.erb": {
+      "filePath": "app/views/posts/_sidebar.html.erb",
+      "contentHash": "632df0c4a4f9297808ecc31f89e77caca0ba9d39161a94cf5b2c992e2822326e",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 57,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/edit.html.erb": {
+      "filePath": "app/views/posts/edit.html.erb",
+      "contentHash": "f952f6d09b68c8038c470582acb1183a077f7e643047a3c10cc6f8412766f3a0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 19,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/index.html.erb": {
+      "filePath": "app/views/posts/index.html.erb",
+      "contentHash": "45ba8932d22ffd2ef49d237217a43e871d56cfdac523ccbb19477016b6320eb9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 210,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/new.html.erb": {
+      "filePath": "app/views/posts/new.html.erb",
+      "contentHash": "60a68b9e9ea1ec3b63e31faa460e9669d60ce7a3c9d12a7df2a84f60ae0dd311",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 19,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/show.html.erb": {
+      "filePath": "app/views/posts/show.html.erb",
+      "contentHash": "fdb046c0c71328f52725c45cc041199590257f725fd888d59740f6ba4169332d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 122,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/posts/show_all.html.erb": {
+      "filePath": "app/views/posts/show_all.html.erb",
+      "contentHash": "96e11562ea2d59aa813a551627f55370067c44186bd505cc288133870df72db1",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 152,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/pwa/manifest.json.erb": {
+      "filePath": "app/views/pwa/manifest.json.erb",
+      "contentHash": "3bef0a9a066b438435087d0d867c5416f1facc46820323508c6718e0fa23fae6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 23,
+      "hasStructuralAnalysis": false
+    },
+    "app/views/pwa/service-worker.js": {
+      "filePath": "app/views/pwa/service-worker.js",
+      "contentHash": "0426be172770a4cd4ac523a616f22c8d3e2c7b457ffd6e9f0e5a6808c6a15791",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 27,
+      "hasStructuralAnalysis": true
+    },
+    "app/views/sessions/new.html.erb": {
+      "filePath": "app/views/sessions/new.html.erb",
+      "contentHash": "14c805ee577961ac84dc6bcba9fe3be8127ea5a1ff2f010df39fdffb8165f204",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 39,
+      "hasStructuralAnalysis": false
+    },
+    "bin/brakeman": {
+      "filePath": "bin/brakeman",
+      "contentHash": "7825743df15f32a7a7a36b2098aec1dd56767031af0181d288f8a563c2c225b0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 8,
+      "hasStructuralAnalysis": false
+    },
+    "bin/bundler-audit": {
+      "filePath": "bin/bundler-audit",
+      "contentHash": "484ba9033e36465898620184f12f427b014bf91ac61a423d302447ea99cf378d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 7,
+      "hasStructuralAnalysis": false
+    },
+    "bin/check-code": {
+      "filePath": "bin/check-code",
+      "contentHash": "0d3163674d8a279a24eb2f78c937237586d5718ce8e9d0d636b74d85d627bebc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 28,
+      "hasStructuralAnalysis": false
+    },
+    "bin/ci": {
+      "filePath": "bin/ci",
+      "contentHash": "ee240fa535e83197c3b79489f56454ec9e1b24f9b7db15eb26c35fc858e12c02",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 7,
+      "hasStructuralAnalysis": false
+    },
+    "bin/dev": {
+      "filePath": "bin/dev",
+      "contentHash": "7a30cf45206be40b4446525717a7eff0099a3fdf2f7dc0ba4472b6815833e038",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 17,
+      "hasStructuralAnalysis": false
+    },
+    "bin/docker-entrypoint": {
+      "filePath": "bin/docker-entrypoint",
+      "contentHash": "e6f4e69ab211df5b889469d1768a86d1f176a6b3861c20704bf1fcab79578d56",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 9,
+      "hasStructuralAnalysis": false
+    },
+    "bin/importmap": {
+      "filePath": "bin/importmap",
+      "contentHash": "aaaf65c0637afc4a2cd13b04660761cfaee83d7f6e81446986a3e3aaafb84da5",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": false
+    },
+    "bin/jobs": {
+      "filePath": "bin/jobs",
+      "contentHash": "7b51c14b8871a220d4227a09c87634c5f20d574c5ea3cdfaeb32fa62e35fc988",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 7,
+      "hasStructuralAnalysis": false
+    },
+    "bin/kamal": {
+      "filePath": "bin/kamal",
+      "contentHash": "9d9795dd6ef45db91f28a71e185555485aab41c09e9bad44014a2a9df27b0c4c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 28,
+      "hasStructuralAnalysis": false
+    },
+    "bin/rails": {
+      "filePath": "bin/rails",
+      "contentHash": "0862d7bc09d5ed61785d677ef2dba10ce285387d4d5d9e3d90d97630e3f69ab6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": false
+    },
+    "bin/rake": {
+      "filePath": "bin/rake",
+      "contentHash": "5943c3811dc345727b5f330b599c4c6c45abc04816dd8f4201aeed88cf268cb3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": false
+    },
+    "bin/rubocop": {
+      "filePath": "bin/rubocop",
+      "contentHash": "62c9fd75681308e1d161f75e96b6af1a837a2f56c9fc9ddf641f1cebf0d7f717",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 9,
+      "hasStructuralAnalysis": false
+    },
+    "bin/setup": {
+      "filePath": "bin/setup",
+      "contentHash": "0f5b139524ceb07af2e32cca242a2817f4df26f0ecf96c64cec402ebcfaa7294",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 36,
+      "hasStructuralAnalysis": false
+    },
+    "bin/thrust": {
+      "filePath": "bin/thrust",
+      "contentHash": "ed1176b4df355db4b2a67ee37b45ca5c6d7118255d28a07dcdcb6d0fe4ae5c4f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 6,
+      "hasStructuralAnalysis": false
+    },
+    "config.ru": {
+      "filePath": "config.ru",
+      "contentHash": "c96fa63843d7367dd76d3afc6525ff20e499a32680510b5d88559efede4b44bb",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 7,
+      "hasStructuralAnalysis": false
+    },
+    "config/application.rb": {
+      "filePath": "config/application.rb",
+      "contentHash": "1d5b184d82a3b5ecc6c352d368096364768ee9aefecc39fcd5ba7b95c071afff",
+      "functions": [],
+      "classes": [
+        {
+          "name": "BlogWithRails",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 36
+        }
+      ],
+      "imports": [
+        {
+          "source": "boot",
+          "specifiers": [
+            "boot"
+          ]
+        },
+        {
+          "source": "rails/all",
+          "specifiers": [
+            "rails/all"
+          ]
+        }
+      ],
+      "exports": [
+        "BlogWithRails"
+      ],
+      "totalLines": 45,
+      "hasStructuralAnalysis": true
+    },
+    "config/boot.rb": {
+      "filePath": "config/boot.rb",
+      "contentHash": "80d2a15db036c064d8a402dca17a3f68b9b3f30bdcbd3771919352e01acbac41",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "bundler/setup",
+          "specifiers": [
+            "bundler/setup"
+          ]
+        },
+        {
+          "source": "bootsnap/setup",
+          "specifiers": [
+            "bootsnap/setup"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "config/brakeman.ignore": {
+      "filePath": "config/brakeman.ignore",
+      "contentHash": "85f477a6756ba6f16411da46fc683c6ab05529bea59f50afbc7e20ed43840225",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 8,
+      "hasStructuralAnalysis": false
+    },
+    "config/bundler-audit.yml": {
+      "filePath": "config/bundler-audit.yml",
+      "contentHash": "66a183a7527771deb7f6c385bbd19cf5a1f49c59339e5fd91b5d49ac5dbefb11",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "config/cable.yml": {
+      "filePath": "config/cable.yml",
+      "contentHash": "02aaf0022d9e349a835a95bcc0c77b504a6e64e2e4af4ce3e61c906ef7e75435",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 18,
+      "hasStructuralAnalysis": true
+    },
+    "config/cache.yml": {
+      "filePath": "config/cache.yml",
+      "contentHash": "bf30bab9f56b2e4dfde078a79c9a31662cd11b24d7ddca7c66e150994d71b9c0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 17,
+      "hasStructuralAnalysis": true
+    },
+    "config/ci.rb": {
+      "filePath": "config/ci.rb",
+      "contentHash": "5c7e60f203dc14613bc74c99c1a27f904c8b92c74d158a37a909b95a1226cdf3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 24,
+      "hasStructuralAnalysis": true
+    },
+    "config/credentials.yml.enc": {
+      "filePath": "config/credentials.yml.enc",
+      "contentHash": "2d303ee8997d30c40d5b08128fd4bf3bfe5e5610a7daeaa14daeed7d111ad34a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "config/database.yml": {
+      "filePath": "config/database.yml",
+      "contentHash": "da9298aca3b94afe63ce23259763d048e360ca31053d4fc9da923a203c7895b0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 53,
+      "hasStructuralAnalysis": true
+    },
+    "config/deploy.yml": {
+      "filePath": "config/deploy.yml",
+      "contentHash": "6478b2dfcfb567edf8ce14633b4d1cc5dfe84bea0b38079acddbfbe1eb4233e3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 130,
+      "hasStructuralAnalysis": true
+    },
+    "config/environment.rb": {
+      "filePath": "config/environment.rb",
+      "contentHash": "4ef42176e9a5230e58dd45866b910a4df0be191d461d271b554573ea6155f12e",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "application",
+          "specifiers": [
+            "application"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "config/environments/development.rb": {
+      "filePath": "config/environments/development.rb",
+      "contentHash": "0a3d4b06df2a91ae34b17939de948b39c08ffc4897f282dc761aa5a4c286d901",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "active_support/core_ext/integer/time",
+          "specifiers": [
+            "active_support/core_ext/integer/time"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 79,
+      "hasStructuralAnalysis": true
+    },
+    "config/environments/production.rb": {
+      "filePath": "config/environments/production.rb",
+      "contentHash": "ecaa36e8090f660b981a180314c1446c6c21a607b11e3a439851e533e9ed4152",
+      "functions": [],
+      "classes": [],
+      "imports": [
+        {
+          "source": "active_support/core_ext/integer/time",
+          "specifiers": [
+            "active_support/core_ext/integer/time"
+          ]
+        }
+      ],
+      "exports": [],
+      "totalLines": 104,
+      "hasStructuralAnalysis": true
+    },
+    "config/environments/test.rb": {
+      "filePath": "config/environments/test.rb",
+      "contentHash": "94e8b064bc56013c197bfed1ba6d0db41cccd24e0b12917820a0bcc86163338a",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 57,
+      "hasStructuralAnalysis": true
+    },
+    "config/importmap.rb": {
+      "filePath": "config/importmap.rb",
+      "contentHash": "22740ed39af24b1bd89f47b60b012a36dd5dae8a6eaa7d41f8e2ecf12bc6c901",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 11,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/action_text.rb": {
+      "filePath": "config/initializers/action_text.rb",
+      "contentHash": "67b02a78eefabe75d3d594c6d95801c72a953ea29d2763bc1c1f6448fb90ed97",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 64,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/assets.rb": {
+      "filePath": "config/initializers/assets.rb",
+      "contentHash": "973dc4c824d9fa050e0818b43744c792bec31b34df045f59520cd0fe5b40eb37",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 8,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/cloudflare.rb": {
+      "filePath": "config/initializers/cloudflare.rb",
+      "contentHash": "70a722d150684e467bc33e393cc9f4a68f91a816845be1aa59bdbb96d4d069ed",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 43,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/content_security_policy.rb": {
+      "filePath": "config/initializers/content_security_policy.rb",
+      "contentHash": "c6f1107bb6ab5cd3b35bfd0e1a8f25905276b4f9e7deb76ef280b94c4f16c444",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 47,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/filter_parameter_logging.rb": {
+      "filePath": "config/initializers/filter_parameter_logging.rb",
+      "contentHash": "950ed0d189d7ca69dbc81d3b0fd9ceab545b9f3fa09a25b47374309cd37f081d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 9,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/inflections.rb": {
+      "filePath": "config/initializers/inflections.rb",
+      "contentHash": "c3ffd0cf930e98b860e3e59cd3e63b311a07d25aeaa5fee3d3d1582dae7a8268",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 17,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/kaminari_config.rb": {
+      "filePath": "config/initializers/kaminari_config.rb",
+      "contentHash": "d4ee8ba1dbcafcaa33218c5723ed7f208bbc76879b13fbbc62cb6de1e4fba011",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 15,
+      "hasStructuralAnalysis": true
+    },
+    "config/initializers/security_headers.rb": {
+      "filePath": "config/initializers/security_headers.rb",
+      "contentHash": "8babd08d9f9c85f73d3d68af3b0cd044a0dd6c3b69d87c6b798438c589d253bc",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 28,
+      "hasStructuralAnalysis": true
+    },
+    "config/locales/en.yml": {
+      "filePath": "config/locales/en.yml",
+      "contentHash": "0715f7ac843016f6aa8cd490a8ea166d4551f0b29c65d1ed49d4ca5330fcf6a8",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 32,
+      "hasStructuralAnalysis": true
+    },
+    "config/puma.rb": {
+      "filePath": "config/puma.rb",
+      "contentHash": "4083d00c5e00e8e56cbce630ff791e69c2f380bd717e92a205717f989ed3bdf6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 74,
+      "hasStructuralAnalysis": true
+    },
+    "config/queue.yml": {
+      "filePath": "config/queue.yml",
+      "contentHash": "b13c0b565957f214811ab44c699edc83d2f0f04b62b3f5c4291e6ccfd663e830",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 19,
+      "hasStructuralAnalysis": true
+    },
+    "config/recurring.yml": {
+      "filePath": "config/recurring.yml",
+      "contentHash": "606a4aa81f16d045de31960c845e378b65a9a6b511fcda3514cf858efe3a52c9",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "config/routes.rb": {
+      "filePath": "config/routes.rb",
+      "contentHash": "10ca5ed6bc94567eda0b1328012fbfac7c9355ab6c5b5bc1cece03742e905e52",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 40,
+      "hasStructuralAnalysis": true
+    },
+    "config/storage.yml": {
+      "filePath": "config/storage.yml",
+      "contentHash": "ad83c27112557372849e6a753590986f74c9fa210e8628cc119a57b78216c17f",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 28,
+      "hasStructuralAnalysis": true
+    },
+    "db/cable_schema.rb": {
+      "filePath": "db/cable_schema.rb",
+      "contentHash": "f2187116262bbf19c747bb45d3f4249e7de1cc935ca3276c6f09b737ce2c98d4",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 12,
+      "hasStructuralAnalysis": true
+    },
+    "db/cache_schema.rb": {
+      "filePath": "db/cache_schema.rb",
+      "contentHash": "6632c0da3211564872a8f276f3b4566ff83917bc7e8d7f9bb2359f31bd26fd46",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 13,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20251122082531_create_posts.rb": {
+      "filePath": "db/migrate/20251122082531_create_posts.rb",
+      "contentHash": "8b2b6b043ab0970c9e566124bb8e9f1fa29ffaaec8ee32b727becd46a2baaf57",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "CreatePosts",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 12
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CreatePosts"
+      ],
+      "totalLines": 13,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20251122082559_create_active_storage_tables.active_storage.rb": {
+      "filePath": "db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+      "contentHash": "3f915dfa8cdc99a1e2ff635a51a263e9c46f99b7eb6fcc5b242bce25d88b6e40",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 45
+        },
+        {
+          "name": "primary_and_foreign_key_types",
+          "params": [],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "CreateActiveStorageTables",
+          "methods": [
+            "change",
+            "primary_and_foreign_key_types"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 56
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CreateActiveStorageTables"
+      ],
+      "totalLines": 58,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20251122082560_create_action_text_tables.action_text.rb": {
+      "filePath": "db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+      "contentHash": "71060d6807747c55badba1b01826fd03bbd5ff78b5a2afd11471a2323b6c70b5",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "primary_and_foreign_key_types",
+          "params": [],
+          "exported": false,
+          "lineCount": 7
+        }
+      ],
+      "classes": [
+        {
+          "name": "CreateActionTextTables",
+          "methods": [
+            "change",
+            "primary_and_foreign_key_types"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 25
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CreateActionTextTables"
+      ],
+      "totalLines": 27,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20251125033932_add_tags_to_posts.rb": {
+      "filePath": "db/migrate/20251125033932_add_tags_to_posts.rb",
+      "contentHash": "b76692abcd846a9e841ad7bef35df33b8957e943c8a12cb0dc92691fdee6bd49",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "AddTagsToPosts",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 5
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "AddTagsToPosts"
+      ],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20251130051704_add_slug_and_category_to_posts.rb": {
+      "filePath": "db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+      "contentHash": "f7b248f9ae8151fbebaffe449ac111d2fce86180fc8e9578d99771c28864eb5d",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 6
+        }
+      ],
+      "classes": [
+        {
+          "name": "AddSlugAndCategoryToPosts",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 8
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "AddSlugAndCategoryToPosts"
+      ],
+      "totalLines": 9,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20260319025507_create_tags_and_posts_tags.rb": {
+      "filePath": "db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "contentHash": "850af85bf528be9f9c714911fd39952b8cedfa3a920b840b906126acf754c487",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 13
+        }
+      ],
+      "classes": [
+        {
+          "name": "CreateTagsAndPostsTags",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 15
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CreateTagsAndPostsTags"
+      ],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20260319034444_remove_tags_string_from_posts.rb": {
+      "filePath": "db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "contentHash": "16089304a10a40817ec398091cc14425bfd3ea8410bb2ba2b816c1e4757a38f6",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "RemoveTagsStringFromPosts",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 5
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "RemoveTagsStringFromPosts"
+      ],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20260324033356_create_admins.rb": {
+      "filePath": "db/migrate/20260324033356_create_admins.rb",
+      "contentHash": "4fa68ddb8e5410463566fec02bae4f6b24a5b55d82fa9b9c246fa6a3edd5db5e",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "classes": [
+        {
+          "name": "CreateAdmins",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 12
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "CreateAdmins"
+      ],
+      "totalLines": 13,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20260731120000_add_published_at_index_to_posts.rb": {
+      "filePath": "db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+      "contentHash": "018bdcc51c1febac0cc857ada9f429210d14fa67490d710813144813ad32365b",
+      "functions": [
+        {
+          "name": "change",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "AddPublishedAtIndexToPosts",
+          "methods": [
+            "change"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 7
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "AddPublishedAtIndexToPosts"
+      ],
+      "totalLines": 8,
+      "hasStructuralAnalysis": true
+    },
+    "db/migrate/20260801060000_add_word_count_to_posts.rb": {
+      "filePath": "db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "contentHash": "fd25d26048f1fa4709622db060ea9d3fb3d6ffd38ef140c2511fb09b20850bf4",
+      "functions": [
+        {
+          "name": "up",
+          "params": [],
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "down",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "AddWordCountToPosts",
+          "methods": [
+            "up",
+            "down"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 17
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "AddWordCountToPosts"
+      ],
+      "totalLines": 18,
+      "hasStructuralAnalysis": true
+    },
+    "db/queue_schema.rb": {
+      "filePath": "db/queue_schema.rb",
+      "contentHash": "41a8a513e9e587f0f44a24e352e5a81470a7bb908b1ea86b960decef31db86b6",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 130,
+      "hasStructuralAnalysis": true
+    },
+    "db/schema.rb": {
+      "filePath": "db/schema.rb",
+      "contentHash": "1f7f50d7b86651a5fa36ee287cb7eaaafecdb2322239e6604757bfccb6c5ef03",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 95,
+      "hasStructuralAnalysis": true
+    },
+    "db/seeds.rb": {
+      "filePath": "db/seeds.rb",
+      "contentHash": "a0cd5b656428ba5fc4a7bdd3eb73045459268be28f38fc79760108baa2a4f818",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 162,
+      "hasStructuralAnalysis": true
+    },
+    "lib/tasks/.keep": {
+      "filePath": "lib/tasks/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "lib/tasks/import_from_sqlite.rake": {
+      "filePath": "lib/tasks/import_from_sqlite.rake",
+      "contentHash": "da8e7d07edf56d21db00861a36acd4e7d4f529ca7fc65cf670602e93869d0c1c",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 207,
+      "hasStructuralAnalysis": true
+    },
+    "lib/tasks/migrate_tags.rake": {
+      "filePath": "lib/tasks/migrate_tags.rake",
+      "contentHash": "c2eea0d4f2702915c6c35a1e4235a5a29665e01ae6f218d6e4e6ba28013373e0",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 68,
+      "hasStructuralAnalysis": true
+    },
+    "public/400.html": {
+      "filePath": "public/400.html",
+      "contentHash": "5648fd0558e301917c88dc3059cf3a19272d515bf7d7c0f46d9de28a228417a3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 136,
+      "hasStructuralAnalysis": false
+    },
+    "public/404.html": {
+      "filePath": "public/404.html",
+      "contentHash": "47511df094501e3ba9b85a41e76cc2bf5c1d9aae192c6fd3ad839710c74f237b",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 136,
+      "hasStructuralAnalysis": false
+    },
+    "public/406-unsupported-browser.html": {
+      "filePath": "public/406-unsupported-browser.html",
+      "contentHash": "3ecfd9e83d13a0b9b0baeef31b69d726f5381c9220d88d486e629ac51a2c1a14",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 136,
+      "hasStructuralAnalysis": false
+    },
+    "public/422.html": {
+      "filePath": "public/422.html",
+      "contentHash": "75e647fa04b4a4d6633427b03694b9fd9d24388fc2fb31e73b35c0fd52bf55f3",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 136,
+      "hasStructuralAnalysis": false
+    },
+    "public/500.html": {
+      "filePath": "public/500.html",
+      "contentHash": "26a261e185277a829432fbee5ea168ce332287abe9a464b420661650ecd2bbe7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 136,
+      "hasStructuralAnalysis": false
+    },
+    "public/robots.txt": {
+      "filePath": "public/robots.txt",
+      "contentHash": "7df2841af8bb1d02a48c14aa641c54f2157a61de7a8a355adef94bbb37ca9be7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 2,
+      "hasStructuralAnalysis": false
+    },
+    "script/.keep": {
+      "filePath": "script/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "script/subset_fonts.py": {
+      "filePath": "script/subset_fonts.py",
+      "contentHash": "ea0f20d94dfb2d56723a44f1ff5154f0e9ad8122b430c194af3dac07ab9057fd",
+      "functions": [
+        {
+          "name": "site_codepoints",
+          "params": [],
+          "returnType": "set[int]",
+          "exported": true,
+          "lineCount": 31
+        },
+        {
+          "name": "main",
+          "params": [],
+          "returnType": "int",
+          "exported": true,
+          "lineCount": 61
+        }
+      ],
+      "classes": [],
+      "imports": [
+        {
+          "source": "glob",
+          "specifiers": [
+            "glob"
+          ]
+        },
+        {
+          "source": "html",
+          "specifiers": [
+            "html"
+          ]
+        },
+        {
+          "source": "os",
+          "specifiers": [
+            "os"
+          ]
+        },
+        {
+          "source": "re",
+          "specifiers": [
+            "re"
+          ]
+        },
+        {
+          "source": "sqlite3",
+          "specifiers": [
+            "sqlite3"
+          ]
+        },
+        {
+          "source": "sys",
+          "specifiers": [
+            "sys"
+          ]
+        }
+      ],
+      "exports": [
+        "site_codepoints",
+        "main"
+      ],
+      "totalLines": 152,
+      "hasStructuralAnalysis": true
+    },
+    "test/application_system_test_case.rb": {
+      "filePath": "test/application_system_test_case.rb",
+      "contentHash": "d034ff7cfef1e165d71a28612f312c946d76e89b00902ee4bc10b242430db65f",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ApplicationSystemTestCase",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 3
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "ApplicationSystemTestCase"
+      ],
+      "totalLines": 6,
+      "hasStructuralAnalysis": true
+    },
+    "test/controllers/.keep": {
+      "filePath": "test/controllers/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/controllers/errors_controller_test.rb": {
+      "filePath": "test/controllers/errors_controller_test.rb",
+      "contentHash": "776496b17f43ed6dd2481aa8eaba54bae95b1fb1de7f699f51669faac92c4f47",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ErrorsControllerTest",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 25
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "ErrorsControllerTest"
+      ],
+      "totalLines": 28,
+      "hasStructuralAnalysis": true
+    },
+    "test/controllers/posts_controller_test.rb": {
+      "filePath": "test/controllers/posts_controller_test.rb",
+      "contentHash": "b232687c6661aedc409098bd4d570411e54c958aac6b14f14cbc6832ce23a296",
+      "functions": [],
+      "classes": [
+        {
+          "name": "PostsControllerTest",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 160
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "PostsControllerTest"
+      ],
+      "totalLines": 163,
+      "hasStructuralAnalysis": true
+    },
+    "test/controllers/sessions_controller_test.rb": {
+      "filePath": "test/controllers/sessions_controller_test.rb",
+      "contentHash": "89722ef78442b0e0110183a70b68e01ee703004f911e820b8498c88cefdf717a",
+      "functions": [],
+      "classes": [
+        {
+          "name": "SessionsControllerTest",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 112
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "SessionsControllerTest"
+      ],
+      "totalLines": 115,
+      "hasStructuralAnalysis": true
+    },
+    "test/controllers/uploads_controller_test.rb": {
+      "filePath": "test/controllers/uploads_controller_test.rb",
+      "contentHash": "f980962a4df71a5aba7a11abbd0b17b89c4e5eb2fc9d4839f12467aa084fe1f8",
+      "functions": [
+        {
+          "name": "png_upload",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "UploadsControllerTest",
+          "methods": [
+            "png_upload"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 74
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "UploadsControllerTest"
+      ],
+      "totalLines": 77,
+      "hasStructuralAnalysis": true
+    },
+    "test/fixtures/action_text/rich_texts.yml": {
+      "filePath": "test/fixtures/action_text/rich_texts.yml",
+      "contentHash": "f57600c950d4d56cf6b1f06271d4493742a5e83350316d236ac2d5424bd73e53",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 5,
+      "hasStructuralAnalysis": true
+    },
+    "test/fixtures/admins.yml": {
+      "filePath": "test/fixtures/admins.yml",
+      "contentHash": "517580ad06cdf2d19841fd5056f3c0673807a49ac0ea061d70f71911017d1bf7",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 4,
+      "hasStructuralAnalysis": true
+    },
+    "test/fixtures/files/.keep": {
+      "filePath": "test/fixtures/files/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/fixtures/posts.yml": {
+      "filePath": "test/fixtures/posts.yml",
+      "contentHash": "5a05a8ebcc0c10693f85250404961533e6abec9552c489d8c1c7b44191cd9e5d",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 16,
+      "hasStructuralAnalysis": true
+    },
+    "test/helpers/.keep": {
+      "filePath": "test/helpers/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/helpers/image_helper_test.rb": {
+      "filePath": "test/helpers/image_helper_test.rb",
+      "contentHash": "66bca4e41e61f2f3a898e7aa0ca551e4948b82e7f885be853d260885c8f979b8",
+      "functions": [
+        {
+          "name": "dimensions_for",
+          "params": [
+            "width",
+            "height",
+            "**limits"
+          ],
+          "exported": false,
+          "lineCount": 4
+        }
+      ],
+      "classes": [
+        {
+          "name": "ImageHelperTest",
+          "methods": [
+            "dimensions_for"
+          ],
+          "properties": [],
+          "exported": true,
+          "lineCount": 35
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "ImageHelperTest"
+      ],
+      "totalLines": 38,
+      "hasStructuralAnalysis": true
+    },
+    "test/integration/.keep": {
+      "filePath": "test/integration/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/mailers/.keep": {
+      "filePath": "test/mailers/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/models/.keep": {
+      "filePath": "test/models/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/models/post_test.rb": {
+      "filePath": "test/models/post_test.rb",
+      "contentHash": "099c4d50f559933c0c3b8d79e850f607fc0ba5bafc415ec094a18532d4c1b8e1",
+      "functions": [],
+      "classes": [
+        {
+          "name": "PostTest",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 277
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "PostTest"
+      ],
+      "totalLines": 280,
+      "hasStructuralAnalysis": true
+    },
+    "test/models/tag_test.rb": {
+      "filePath": "test/models/tag_test.rb",
+      "contentHash": "e5ff5ed45a054bdd3ecdfe325355f346852a2bd8ee7a06d995052816a2e313ea",
+      "functions": [],
+      "classes": [
+        {
+          "name": "TagTest",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 49
+        }
+      ],
+      "imports": [
+        {
+          "source": "test_helper",
+          "specifiers": [
+            "test_helper"
+          ]
+        }
+      ],
+      "exports": [
+        "TagTest"
+      ],
+      "totalLines": 52,
+      "hasStructuralAnalysis": true
+    },
+    "test/system/.keep": {
+      "filePath": "test/system/.keep",
+      "contentHash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "functions": [],
+      "classes": [],
+      "imports": [],
+      "exports": [],
+      "totalLines": 1,
+      "hasStructuralAnalysis": false
+    },
+    "test/test_helper.rb": {
+      "filePath": "test/test_helper.rb",
+      "contentHash": "8325f6b85a8a825536b3febad8ccd3517c63248160b6f30a20d5cb4ae27ce0e3",
+      "functions": [],
+      "classes": [
+        {
+          "name": "ActiveSupport",
+          "methods": [],
+          "properties": [],
+          "exported": true,
+          "lineCount": 36
+        }
+      ],
+      "imports": [
+        {
+          "source": "simplecov",
+          "specifiers": [
+            "simplecov"
+          ]
+        },
+        {
+          "source": "../config/environment",
+          "specifiers": [
+            "../config/environment"
+          ]
+        },
+        {
+          "source": "rails/test_help",
+          "specifiers": [
+            "rails/test_help"
+          ]
+        }
+      ],
+      "exports": [
+        "ActiveSupport"
+      ],
+      "totalLines": 59,
+      "hasStructuralAnalysis": true
+    }
+  }
+}

--- a/.ua/knowledge-graph.json
+++ b/.ua/knowledge-graph.json
@@ -1,0 +1,6603 @@
+{
+  "nodes": [
+    {
+      "id": "service:.dockerignore",
+      "type": "service",
+      "name": ".dockerignore",
+      "filePath": ".dockerignore",
+      "summary": "Docker 빌드 컨텍스트에서 제외할 파일 목록을 정의한다. .git, 환경 변수 파일(.env*), master.key 등 비밀 키, 로그/임시 파일, storage 업로드, Kamal 배포 설정(.kamal, config/deploy*.yml)을 이미지에 포함시키지 않아 빌드 속도와 보안을 확보한다.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "빌드-컨텍스트",
+        "보안"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:Dockerfile",
+      "type": "service",
+      "name": "Dockerfile",
+      "filePath": "Dockerfile",
+      "summary": "Ruby 3.4.5-slim 기반 3단계 멀티 스테이지 빌드로 Rails 8 프로덕션 이미지를 생성한다. base 스테이지에서 런타임 패키지(libvips, libjemalloc2, postgresql-client, sqlite3)를 설치하고, build 스테이지에서 gem 설치·bootsnap 프리컴파일·에셋 프리컴파일을 수행한 뒤, 최종 스테이지는 비루트 rails(1000:1000) 유저로 80 포트에서 thrust 프록시를 통해 Rails 서버를 구동한다.",
+      "tags": [
+        "containerization",
+        "infrastructure",
+        "deployment",
+        "멀티-스테이지-빌드"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "멀티 스테이지 빌드로 빌드 도구(build-essential, git 등)를 최종 이미지에서 제거해 이미지 크기를 최소화하고, SECRET_KEY_BASE_DUMMY=1 기법으로 실제 비밀 키 없이 에셋을 프리컴파일한다. CLAUDE.md에 명시된 대로 ruby-vips가 FFI로 로드하는 libvips 시스템 라이브러리를 CI와 동일하게 설치한다."
+    },
+    {
+      "id": "service:Dockerfile:base",
+      "type": "service",
+      "name": "base",
+      "filePath": "Dockerfile",
+      "lineRange": [
+        12,
+        30
+      ],
+      "summary": "ruby:3.4.5-slim을 기반으로 하는 공통 베이스 스테이지. /rails 작업 디렉터리를 설정하고 curl, libjemalloc2, libvips, postgresql-client, sqlite3 등 런타임 패키지를 설치하며 RAILS_ENV=production 등 프로덕션 환경 변수를 정의한다.",
+      "tags": [
+        "containerization",
+        "베이스-이미지",
+        "런타임-패키지"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "service:Dockerfile:build",
+      "type": "service",
+      "name": "build",
+      "filePath": "Dockerfile",
+      "lineRange": [
+        31,
+        57
+      ],
+      "summary": "빌드 전용 스테이지로 build-essential·git·pkg-config 등 빌드 도구를 설치한 뒤 bundle install, bootsnap 프리컴파일, assets:precompile을 수행한다. 산출물만 최종 스테이지로 복사되므로 빌드 도구는 프로덕션 이미지에 남지 않는다.",
+      "tags": [
+        "containerization",
+        "빌드-스테이지",
+        "asset-precompile"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:.rubocop.yml",
+      "type": "config",
+      "name": ".rubocop.yml",
+      "filePath": ".rubocop.yml",
+      "summary": "rubocop-rails-omakase gem의 규칙을 그대로 상속하는 RuboCop 설정 파일. Rails 기본(Omakase) 스타일을 채택하며 프로젝트 자체 오버라이드 규칙은 아직 없다.",
+      "tags": [
+        "configuration",
+        "lint",
+        "코드-스타일",
+        "ruby"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:CLAUDE.md",
+      "type": "document",
+      "name": "CLAUDE.md",
+      "filePath": "CLAUDE.md",
+      "summary": "Claude Code를 위한 아키텍처 가이드 문서. 개발·테스트·품질 게이트 명령어, DB 토폴로지(개발 SQLite/프로덕션 Supabase PostgreSQL), Devise 없는 세션 기반 관리자 인증, 게시글 공개 범위와 HTTP 캐싱, 코드 블록 Base64 파이프라인, 3가지 이미지 서빙 경로, 보안 설정(CSP report-only, Cloudflare 신뢰 프록시) 등 프로젝트의 핵심 규약을 정리한다.",
+      "tags": [
+        "documentation",
+        "아키텍처-가이드",
+        "개발-규약",
+        "onboarding"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Action Text sanitizer가 코드 블록 내 HTML 엔티티를 손상시키는 문제를 우회하는 Base64 인코딩 파이프라인이 4개 파일(PostsController, Post 모델, init.js, action_text 초기화자)에 걸쳐 있음을 명시한 것이 이 문서의 가장 중요한 내용이다."
+    },
+    {
+      "id": "document:README.md",
+      "type": "document",
+      "name": "README.md",
+      "filePath": "README.md",
+      "summary": "프로젝트 개요 문서(한국어). 기술 스택 배지, 설치·실행 방법, Post/Tag 모델의 데이터베이스 스키마와 주요 메서드·스코프, 핵심 기능(TinyMCE 에디터, 관리자 인증, 태그 시스템, HTTP 캐싱, 반응형 이미지), 환경 변수, 코드 품질 체크와 Kamal 배포 가이드를 담고 있다.",
+      "tags": [
+        "documentation",
+        "entry-point",
+        "overview",
+        "설치-가이드"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "config:config/bundler-audit.yml",
+      "type": "config",
+      "name": "bundler-audit.yml",
+      "filePath": "config/bundler-audit.yml",
+      "summary": "bundler-audit 보안 검사 설정 파일로, Gemfile의 gem들을 알려진 CVE 취약점과 대조할 때 무시할 CVE 목록(ignore)을 정의한다. 현재는 자리표시자 항목(CVE-THAT-DOES-NOT-APPLY)만 등록되어 있다.",
+      "tags": [
+        "configuration",
+        "security",
+        "dependency-audit",
+        "취약점-검사"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:config/cable.yml",
+      "type": "config",
+      "name": "cable.yml",
+      "filePath": "config/cable.yml",
+      "summary": "Action Cable 어댑터 설정으로, 개발 환경은 async, 테스트는 test, 프로덕션은 Solid Cable을 사용해 cable 데이터베이스에 연결한다. 프로덕션에서 polling_interval 0.1초, 메시지 보존 기간 1일로 설정되어 있다.",
+      "tags": [
+        "configuration",
+        "websocket",
+        "action-cable",
+        "solid-cable"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Rails 8의 Solid Cable은 Redis 없이 데이터베이스 폴링 방식으로 WebSocket 메시지를 브로드캐스트하는 어댑터이다."
+    },
+    {
+      "id": "config:config/cache.yml",
+      "type": "config",
+      "name": "cache.yml",
+      "filePath": "config/cache.yml",
+      "summary": "Solid Cache 저장소 설정으로, 캐시 최대 크기를 256MB로 제한하고 Rails 환경명을 namespace로 사용한다. 프로덕션에서는 전용 cache 데이터베이스를 사용하도록 지정한다.",
+      "tags": [
+        "configuration",
+        "cache",
+        "solid-cache",
+        "성능"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:config/database.yml",
+      "type": "config",
+      "name": "database.yml",
+      "filePath": "config/database.yml",
+      "summary": "멀티 데이터베이스 구성 파일로, 개발·테스트는 SQLite, 프로덕션 primary는 Supabase PostgreSQL(session pooler, SSL 필수)을 사용한다. 프로덕션의 Solid Cache/Queue/Cable용 보조 데이터베이스는 모두 로컬 SQLite 파일로 분리되어 있다.",
+      "tags": [
+        "configuration",
+        "database",
+        "postgresql",
+        "sqlite",
+        "supabase"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Supabase transaction pooler(포트 6543)는 prepared statement를 지원하지 않으므로 prepared_statements: false로 설정한 점이 특징이다. Rails 8의 primary + cache/queue/cable 4-DB 구성을 그대로 따른다."
+    },
+    {
+      "id": "config:config/deploy.yml",
+      "type": "config",
+      "name": "deploy.yml",
+      "filePath": "config/deploy.yml",
+      "summary": "Kamal 배포 설정 파일로, blog_with_rails 컨테이너 이미지를 Docker Hub에 푸시하고 웹 서버에 배포한다. RAILS_MASTER_KEY·Supabase 비밀번호 등의 secret 주입, Cloudflare Tunnel용 ALLOWED_HOSTS/APP_HOST, SQLite·Active Storage 영속 볼륨, amd64 빌더 설정을 포함한다.",
+      "tags": [
+        "configuration",
+        "deployment",
+        "kamal",
+        "containerization",
+        "infrastructure"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "SOLID_QUEUE_IN_PUMA: true로 별도 잡 서버 없이 Puma 프로세스 내부에서 Solid Queue supervisor를 실행하는 단일 서버 구성을 취한다."
+    },
+    {
+      "id": "config:config/queue.yml",
+      "type": "config",
+      "name": "queue.yml",
+      "filePath": "config/queue.yml",
+      "summary": "Solid Queue 백그라운드 잡 처리 설정으로, dispatcher(폴링 1초, 배치 500건)와 worker(전체 큐, 스레드 3개, JOB_CONCURRENCY 환경변수로 프로세스 수 제어)를 정의한다. 모든 환경이 동일한 기본 구성을 공유한다.",
+      "tags": [
+        "configuration",
+        "background-job",
+        "solid-queue",
+        "비동기-처리"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:config/recurring.yml",
+      "type": "config",
+      "name": "recurring.yml",
+      "filePath": "config/recurring.yml",
+      "summary": "Solid Queue 반복 작업 스케줄 설정으로, 프로덕션에서 매시 12분에 완료된 잡 레코드를 배치 단위로 정리하는 clear_solid_queue_finished_jobs 작업을 등록한다.",
+      "tags": [
+        "configuration",
+        "scheduler",
+        "solid-queue",
+        "cron",
+        "정리-작업"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:config/storage.yml",
+      "type": "config",
+      "name": "storage.yml",
+      "filePath": "config/storage.yml",
+      "summary": "Active Storage 서비스 설정으로, 테스트는 tmp/storage, 로컬(local)은 storage 디렉터리를 사용하는 Disk 서비스를 정의한다. S3·GCS·Mirror 서비스는 주석 처리된 예시로만 남아 있어 파일 업로드가 서버 디스크에 저장된다.",
+      "tags": [
+        "configuration",
+        "active-storage",
+        "file-upload",
+        "disk-storage"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:public/400.html",
+      "type": "file",
+      "name": "400.html",
+      "filePath": "public/400.html",
+      "summary": "클라이언트 오류(400 Bad Request) 발생 시 웹 서버가 직접 제공하는 정적 오류 페이지로, 요청을 확인하고 다시 시도하라는 안내를 표시한다. 인라인 CSS와 SVG 오류 코드 그래픽만으로 구성된 자립형 HTML이다.",
+      "tags": [
+        "error-page",
+        "static-asset",
+        "markup",
+        "오류-처리"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:public/404.html",
+      "type": "file",
+      "name": "404.html",
+      "filePath": "public/404.html",
+      "summary": "존재하지 않는 페이지(404 Not Found) 요청 시 표시되는 정적 오류 페이지로, 주소 오타 또는 페이지 이동 가능성을 안내한다. noindex 메타 태그와 다크 모드 대응 인라인 스타일을 갖춘 Rails 8 표준 오류 페이지이다.",
+      "tags": [
+        "error-page",
+        "static-asset",
+        "markup",
+        "오류-처리"
+      ],
+      "complexity": "simple",
+      "languageNotes": "prefers-color-scheme 미디어 쿼리로 다크 모드를 지원하고, 오류 코드를 텍스트 대신 SVG path로 렌더링하는 Rails 8 기본 오류 페이지 패턴이다. 외부 리소스 없이 완전히 자립형이라 앱이 죽어도 표시된다."
+    },
+    {
+      "id": "file:public/406-unsupported-browser.html",
+      "type": "file",
+      "name": "406-unsupported-browser.html",
+      "filePath": "public/406-unsupported-browser.html",
+      "summary": "Rails 8의 브라우저 버전 가드(allow_browser)가 지원하지 않는 브라우저를 감지했을 때(406 Not Acceptable) 표시되는 정적 페이지로, 브라우저 업그레이드를 안내한다.",
+      "tags": [
+        "error-page",
+        "static-asset",
+        "browser-support",
+        "markup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:public/422.html",
+      "type": "file",
+      "name": "422.html",
+      "filePath": "public/422.html",
+      "summary": "요청한 변경이 거부되었을 때(422 Unprocessable Entity, 주로 CSRF 검증 실패나 권한 문제) 표시되는 정적 오류 페이지로, 접근 권한이 없는 변경 시도 가능성을 안내한다.",
+      "tags": [
+        "error-page",
+        "static-asset",
+        "markup",
+        "오류-처리"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:public/500.html",
+      "type": "file",
+      "name": "500.html",
+      "filePath": "public/500.html",
+      "summary": "서버 내부 오류(500 Internal Server Error) 발생 시 표시되는 정적 오류 페이지로, 애플리케이션 소유자에게 로그 확인을 안내한다. Rails 앱 자체가 응답 불능일 때도 웹 서버가 직접 제공할 수 있는 자립형 HTML이다.",
+      "tags": [
+        "error-page",
+        "static-asset",
+        "markup",
+        "오류-처리"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "document:public/robots.txt",
+      "type": "document",
+      "name": "robots.txt",
+      "filePath": "public/robots.txt",
+      "summary": "검색 엔진 크롤러 제어 파일로, 현재는 robotstxt.org 문서 링크 주석 한 줄만 있어 아무 규칙도 정의하지 않는다. 규칙이 없으므로 사이트 전체 크롤링이 기본 허용된다.",
+      "tags": [
+        "seo",
+        "crawler",
+        "static-asset",
+        "documentation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.gitattributes",
+      "type": "file",
+      "name": ".gitattributes",
+      "filePath": ".gitattributes",
+      "summary": "Git 속성 설정 파일로, db/schema.rb를 자동 생성 파일로 표시하고 bin/* 실행 스크립트를 항상 LF 줄바꿈으로 체크아웃하도록 강제한다. Windows에서 CRLF로 받으면 Docker 빌드 시 bin/rails의 shebang이 깨지는 문제를 방지한다.",
+      "tags": [
+        "git",
+        "configuration",
+        "line-endings",
+        "docker-호환성"
+      ],
+      "complexity": "simple",
+      "languageNotes": "linguist-generated/linguist-vendored 속성으로 GitHub 언어 통계에서 생성·벤더 파일을 제외하고, rails_credentials diff 드라이버로 암호화된 credentials 파일의 diff를 지원한다."
+    },
+    {
+      "id": "config:.github/dependabot.yml",
+      "type": "config",
+      "name": "dependabot.yml",
+      "filePath": ".github/dependabot.yml",
+      "summary": "GitHub Dependabot 설정으로, bundler(Ruby gem)와 github-actions 두 생태계의 의존성을 매주 검사하여 각각 최대 10개의 업데이트 PR을 자동 생성한다.",
+      "tags": [
+        "configuration",
+        "dependency-update",
+        "ci-cd",
+        "자동화"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/docker-setup.sample",
+      "type": "file",
+      "name": "docker-setup.sample",
+      "filePath": ".kamal/hooks/docker-setup.sample",
+      "summary": "Kamal 배포 시 Docker 셋업 단계에서 실행되는 hook의 샘플 파일로, 대상 호스트 목록을 출력하는 3줄짜리 예시 셸 스크립트이다. .sample 확장자이므로 실제로는 비활성 상태다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "sample"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/post-app-boot.sample",
+      "type": "file",
+      "name": "post-app-boot.sample",
+      "filePath": ".kamal/hooks/post-app-boot.sample",
+      "summary": "Kamal이 앱 컨테이너 부팅 직후 실행하는 post-app-boot hook의 샘플로, 부팅 완료 메시지를 출력하는 비활성 예시 스크립트이다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "sample"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/post-deploy.sample",
+      "type": "file",
+      "name": "post-deploy.sample",
+      "filePath": ".kamal/hooks/post-deploy.sample",
+      "summary": "Kamal 배포 완료 후 실행되는 post-deploy hook 샘플로, 배포자·버전·대상·소요 시간을 담은 알림 메시지를 출력한다. KAMAL_* 환경 변수 활용 방법을 보여 주는 비활성 예시다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "sample",
+        "알림"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/post-proxy-reboot.sample",
+      "type": "file",
+      "name": "post-proxy-reboot.sample",
+      "filePath": ".kamal/hooks/post-proxy-reboot.sample",
+      "summary": "Kamal 프록시(kamal-proxy) 재부팅 직후 실행되는 hook의 샘플로, 재부팅 완료를 알리는 3줄짜리 비활성 예시 스크립트이다.",
+      "tags": [
+        "kamal",
+        "proxy",
+        "hook",
+        "sample"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/pre-app-boot.sample",
+      "type": "file",
+      "name": "pre-app-boot.sample",
+      "filePath": ".kamal/hooks/pre-app-boot.sample",
+      "summary": "Kamal이 앱 컨테이너를 부팅하기 직전 실행하는 pre-app-boot hook의 샘플로, 부팅 예정 메시지를 출력하는 비활성 예시 스크립트이다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "sample"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/pre-build.sample",
+      "type": "file",
+      "name": "pre-build.sample",
+      "filePath": ".kamal/hooks/pre-build.sample",
+      "summary": "Kamal 이미지 빌드 전 실행되는 pre-build hook 샘플로, git 체크아웃이 깨끗한지, remote가 설정되어 있는지, 현재 브랜치가 remote에 푸시되었는지, 배포 버전(KAMAL_VERSION)이 remote HEAD와 일치하는지를 검증하고 불일치 시 빌드를 중단한다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "validation",
+        "git"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/hooks/pre-connect.sample",
+      "type": "file",
+      "name": "pre-connect.sample",
+      "filePath": ".kamal/hooks/pre-connect.sample",
+      "summary": "Kamal이 배포 대상 호스트에 접속하기 전 실행되는 pre-connect hook 샘플로, KAMAL_HOSTS의 각 호스트에 대해 스레드를 띄워 DNS 조회를 병렬로 워밍업하고 실패 시 재시도하는 Ruby 스크립트이다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "dns",
+        "병렬처리"
+      ],
+      "complexity": "simple",
+      "languageNotes": "호스트별 Thread를 생성해 Resolv DNS 조회를 병렬 수행하고 Benchmark.realtime으로 소요 시간을 측정하는 Ruby 동시성 패턴을 보여 준다."
+    },
+    {
+      "id": "file:.kamal/hooks/pre-deploy.sample",
+      "type": "file",
+      "name": "pre-deploy.sample",
+      "filePath": ".kamal/hooks/pre-deploy.sample",
+      "summary": "Kamal 배포 직전 실행되는 pre-deploy hook 샘플로, octokit gem을 이용해 배포할 커밋의 GitHub combined status를 최대 720초까지 폴링하며 빌드 성공(success)일 때만 배포를 진행한다. rollback이거나 production 대상이 아니면 검사를 건너뛴다.",
+      "tags": [
+        "kamal",
+        "deployment",
+        "hook",
+        "ci-cd",
+        "github-api"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "bundler/inline의 gemfile 블록으로 스크립트 안에서 octokit·faraday-retry gem을 즉석 설치하는 self-contained Ruby 스크립트 패턴을 사용한다."
+    },
+    {
+      "id": "file:.kamal/hooks/pre-proxy-reboot.sample",
+      "type": "file",
+      "name": "pre-proxy-reboot.sample",
+      "filePath": ".kamal/hooks/pre-proxy-reboot.sample",
+      "summary": "Kamal 프록시 재부팅 직전 실행되는 hook의 샘플로, 재부팅 예정 호스트를 알리는 3줄짜리 비활성 예시 스크립트이다.",
+      "tags": [
+        "kamal",
+        "proxy",
+        "hook",
+        "sample"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.kamal/secrets",
+      "type": "file",
+      "name": "secrets",
+      "filePath": ".kamal/secrets",
+      "summary": "Kamal 배포 시 config/deploy.yml에서 참조할 비밀 값들의 매핑 파일로, RAILS_MASTER_KEY는 config/master.key에서 읽고 ADMIN_EMAIL/ADMIN_PASSWORD(관리자 세션 인증), SUPABASE_DB_PASSWORD(PostgreSQL), TINYMCE_API_KEY는 환경 변수에서 가져온다. 원본 자격 증명은 저장하지 않아 git에 안전하다.",
+      "tags": [
+        "kamal",
+        "secrets",
+        "deployment",
+        "환경변수",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:.ruby-version",
+      "type": "file",
+      "name": ".ruby-version",
+      "filePath": ".ruby-version",
+      "summary": "프로젝트가 사용하는 Ruby 버전을 3.4.5로 고정하는 한 줄짜리 버전 핀 파일로, rbenv/asdf 같은 버전 관리자와 CI, Docker 빌드가 이 값을 참조한다.",
+      "tags": [
+        "ruby",
+        "version-pin",
+        "toolchain"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:Gemfile",
+      "type": "file",
+      "name": "Gemfile",
+      "filePath": "Gemfile",
+      "summary": "프로젝트의 Ruby gem 의존성 매니페스트로, Rails 8.1 + Propshaft + Hotwire(turbo-rails/stimulus-rails/importmap-rails) 스택과 pg(Supabase PostgreSQL), sqlite3(Solid Cache/Queue/Cable), image_processing + ruby-vips(Active Storage 변환), kamal/thruster(배포), kaminari(페이지네이션), bcrypt(인증)를 선언한다. 개발·테스트 그룹에는 dotenv, brakeman, bundler-audit, rubocop, capybara, simplecov를 포함한다.",
+      "tags": [
+        "dependency-manifest",
+        "bundler",
+        "rails",
+        "gems"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Tailwind를 제거하고 커스텀 CSS를 쓰며, Node 툴체인 없이 importmap 기반 ESM을 사용하는 no-build 프런트엔드 구성이다. Rails 8의 Solid 3종(solid_cache/queue/cable)을 로컬 sqlite3로 돌리고 주 데이터베이스만 PostgreSQL을 쓰는 하이브리드 구성이 특징이다."
+    },
+    {
+      "id": "file:Procfile.dev",
+      "type": "file",
+      "name": "Procfile.dev",
+      "filePath": "Procfile.dev",
+      "summary": "개발 환경 프로세스 정의 파일로, web 프로세스 하나만 정의해 bin/rails server를 실행한다. CSS/JS 빌드 워처가 없는 no-build 구성을 반영한다.",
+      "tags": [
+        "development",
+        "process-manager",
+        "entry-point"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:Rakefile",
+      "type": "file",
+      "name": "Rakefile",
+      "filePath": "Rakefile",
+      "summary": "Rake 태스크의 진입점으로, config/application을 로드한 뒤 Rails.application.load_tasks를 호출해 Rails 내장 태스크와 lib/tasks/*.rake 커스텀 태스크를 모두 등록한다.",
+      "tags": [
+        "entry-point",
+        "rake",
+        "build-system"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/assets/images/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "app/assets/images/.keep",
+      "summary": "빈 디렉터리 app/assets/images가 git에 추적되도록 유지하는 0바이트 플레이스홀더 파일이다.",
+      "tags": [
+        "placeholder",
+        "git",
+        "assets"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/controllers/concerns/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "app/controllers/concerns/.keep",
+      "summary": "빈 디렉터리 app/controllers/concerns가 git에 추적되도록 유지하는 0바이트 플레이스홀더 파일이다.",
+      "tags": [
+        "placeholder",
+        "git",
+        "rails-convention"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/controllers/errors_controller.rb",
+      "type": "file",
+      "name": "errors_controller.rb",
+      "filePath": "app/controllers/errors_controller.rb",
+      "summary": "커스텀 에러 페이지(404, 422, 500)를 렌더링하는 컨트롤러 파일로, 404 페이지에서는 인기 태그 10개를 함께 조회해 사용자에게 탐색 경로를 제공한다.",
+      "tags": [
+        "controller",
+        "error-handling",
+        "에러페이지",
+        "tested"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:app/controllers/errors_controller.rb:ErrorsController",
+      "type": "class",
+      "name": "ErrorsController",
+      "filePath": "app/controllers/errors_controller.rb",
+      "lineRange": [
+        3,
+        16
+      ],
+      "summary": "커스텀 에러 페이지를 담당하는 컨트롤러로, not_found(404, 인기 태그 10개 조회 포함), unprocessable(422), internal_server(500) 세 액션이 각각 해당 HTTP 상태 코드와 함께 전용 뷰를 렌더링한다.",
+      "tags": [
+        "controller",
+        "error-handling",
+        "http-status",
+        "에러페이지"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/helpers/posts_helper.rb",
+      "type": "file",
+      "name": "posts_helper.rb",
+      "filePath": "app/helpers/posts_helper.rb",
+      "summary": "scaffold가 생성한 빈 PostsHelper 모듈로, 게시글 뷰 전용 헬퍼는 아직 정의되어 있지 않다.",
+      "tags": [
+        "utility",
+        "helper",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/javascript/controllers/application.js",
+      "type": "file",
+      "name": "application.js",
+      "filePath": "app/javascript/controllers/application.js",
+      "summary": "Stimulus Application 인스턴스를 시작하고 디버그 모드를 끈 뒤 window.Stimulus로 노출하는 부트스트랩 모듈. application 객체를 export해 컨트롤러 등록에 사용된다.",
+      "tags": [
+        "bootstrap",
+        "stimulus",
+        "singleton"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/javascript/controllers/index.js",
+      "type": "file",
+      "name": "index.js",
+      "filePath": "app/javascript/controllers/index.js",
+      "summary": "eagerLoadControllersFrom으로 importmap에 핀된 controllers/**/*_controller 모듈을 일괄 등록하는 Stimulus 컨트롤러 barrel 파일이다.",
+      "tags": [
+        "barrel",
+        "entry-point",
+        "stimulus",
+        "auto-registration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/javascript/controllers/search_controller.js",
+      "type": "file",
+      "name": "search_controller.js",
+      "filePath": "app/javascript/controllers/search_controller.js",
+      "summary": "검색 모달의 열기/닫기를 담당하는 Stimulus 컨트롤러(data-controller=\"search\"). requestAnimationFrame 기반 페이드 인/아웃 애니메이션, 입력창 자동 포커스, ESC 키 닫기를 구현한다.",
+      "tags": [
+        "component",
+        "stimulus",
+        "modal",
+        "animation",
+        "검색"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:app/javascript/controllers/search_controller.js:SearchController",
+      "type": "class",
+      "name": "SearchController",
+      "filePath": "app/javascript/controllers/search_controller.js",
+      "lineRange": [
+        4,
+        72
+      ],
+      "summary": "Stimulus Controller를 상속하는 익명 default export 클래스로 modal 타깃 하나를 사용한다. open/close/closeOnEscape 액션과 fadeInModal/fadeOutModal 애니메이션 메서드로 구성된다.",
+      "tags": [
+        "stimulus",
+        "controller",
+        "modal",
+        "event-handler"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Stimulus 관례상 파일명(search_controller.js)이 곧 식별자 \"search\"가 되므로 클래스 자체는 익명으로 export된다."
+    },
+    {
+      "id": "function:app/javascript/controllers/search_controller.js:fadeInModal",
+      "type": "function",
+      "name": "fadeInModal",
+      "filePath": "app/javascript/controllers/search_controller.js",
+      "lineRange": [
+        33,
+        50
+      ],
+      "summary": "CSS transition 없이 requestAnimationFrame 루프로 300ms 동안 opacity를 0→1로 올리며 모달을 표시한다.",
+      "tags": [
+        "animation",
+        "raf",
+        "modal"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/javascript/controllers/search_controller.js:fadeOutModal",
+      "type": "function",
+      "name": "fadeOutModal",
+      "filePath": "app/javascript/controllers/search_controller.js",
+      "lineRange": [
+        53,
+        71
+      ],
+      "summary": "requestAnimationFrame 루프로 opacity를 1→0으로 내린 뒤 완료 시점에 display:none 처리해 모달을 닫는다.",
+      "tags": [
+        "animation",
+        "raf",
+        "modal"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/javascript/init.js",
+      "type": "file",
+      "name": "init.js",
+      "filePath": "app/javascript/init.js",
+      "summary": "Turbo 페이지 로드마다 실행되는 사이트 초기화 스크립트. TinyMCE 에디터 설정(이미지 업로드 XHR, 코드 블록 Base64 인코딩/디코딩, turbo:false 링크 보정), Prism 코드 하이라이팅, 맨 위로 스크롤 버튼, 링크 복사 기능을 담당한다.",
+      "tags": [
+        "entry-point",
+        "tinymce",
+        "editor",
+        "dom-초기화",
+        "turbo"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Turbo 내비게이션과 공존하기 위해 turbo:load 시점마다 idempotent하게 재초기화하는 패턴(data-attribute 가드, 리스너 제거 후 재등록)을 사용한다."
+    },
+    {
+      "id": "function:app/javascript/init.js:decodeBase64CodeBlock",
+      "type": "function",
+      "name": "decodeBase64CodeBlock",
+      "filePath": "app/javascript/init.js",
+      "lineRange": [
+        16,
+        32
+      ],
+      "summary": "서버가 Base64로 인코딩해 저장한 코드 블록 문자열을 atob와 percent-encoding 우회를 통해 UTF-8 안전하게 디코딩한다. 실패 시 경고 로그 후 원문을 반환한다.",
+      "tags": [
+        "base64",
+        "decoding",
+        "code-block",
+        "utf-8"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/javascript/init.js:decodeLegacyErbPlaceholders",
+      "type": "function",
+      "name": "decodeLegacyErbPlaceholders",
+      "filePath": "app/javascript/init.js",
+      "lineRange": [
+        48,
+        67
+      ],
+      "summary": "Base64 인코딩 도입 이전에 저장된 게시글의 ERB/HTML placeholder 표기를 실제 문자로 복원하고 TinyMCE 표시용으로 재인코딩하는 하위 호환 변환 함수다.",
+      "tags": [
+        "legacy",
+        "migration",
+        "code-block",
+        "호환성"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/javascript/init.js:initTinyMCE",
+      "type": "function",
+      "name": "initTinyMCE",
+      "filePath": "app/javascript/init.js",
+      "lineRange": [
+        69,
+        305
+      ],
+      "summary": "게시글 편집 화면에서 TinyMCE를 초기화하는 중심 함수. XHR 기반 /uploads/image 업로드 핸들러, 파일 선택 picker, 코드 블록 Base64 디코딩(BeforeSetContent), 에디터 내 링크에 data-turbo=false 부여, 폼 제출 전 editor.save 동기화를 설정한다.",
+      "tags": [
+        "tinymce",
+        "editor",
+        "upload",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:app/javascript/init.js:handleCopyLink",
+      "type": "function",
+      "name": "handleCopyLink",
+      "filePath": "app/javascript/init.js",
+      "lineRange": [
+        323,
+        348
+      ],
+      "summary": "현재 게시글 URL을 navigator.clipboard로 복사하고 성공 시 알림 토스트를 2초간 표시한다. Clipboard API 실패 시 textarea + execCommand 폴백을 사용한다.",
+      "tags": [
+        "clipboard",
+        "share",
+        "fallback",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/javascript/init.js:initializePage",
+      "type": "function",
+      "name": "initializePage",
+      "filePath": "app/javascript/init.js",
+      "lineRange": [
+        351,
+        399
+      ],
+      "summary": "turbo:load마다 호출되는 페이지 초기화 진입점으로 Prism 하이라이팅, 스크롤 상단 버튼(스크롤 감지·부드러운 이동), 링크 복사 버튼 바인딩, TinyMCE 초기화를 순서대로 수행한다. 중복 바인딩은 속성 가드로 방지한다.",
+      "tags": [
+        "entry-point",
+        "dom-초기화",
+        "event-handler",
+        "turbo"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:app/jobs/application_job.rb",
+      "type": "file",
+      "name": "application_job.rb",
+      "filePath": "app/jobs/application_job.rb",
+      "summary": "모든 백그라운드 잡의 기반이 되는 ActiveJob::Base 상속 추상 클래스. 재시도/폐기 정책은 주석 처리된 기본 뼈대 상태다.",
+      "tags": [
+        "background-job",
+        "base-class",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/mailers/application_mailer.rb",
+      "type": "file",
+      "name": "application_mailer.rb",
+      "filePath": "app/mailers/application_mailer.rb",
+      "summary": "모든 메일러의 기반이 되는 ActionMailer::Base 상속 클래스로 기본 발신자와 mailer 레이아웃을 지정하는 Rails 표준 뼈대다.",
+      "tags": [
+        "mailer",
+        "base-class",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/models/admin.rb",
+      "type": "file",
+      "name": "admin.rb",
+      "filePath": "app/models/admin.rb",
+      "summary": "블로그 관리자 계정 모델. has_secure_password로 bcrypt 비밀번호 인증을 제공하고, 이메일은 형식·유일성 검증과 함께 normalizes로 소문자 트림 정규화된다.",
+      "tags": [
+        "data-model",
+        "authentication",
+        "validation",
+        "관리자"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Rails 7.1+의 normalizes API로 저장 전 이메일 정규화를 선언적으로 처리한다."
+    },
+    {
+      "id": "class:app/models/admin.rb:Admin",
+      "type": "class",
+      "name": "Admin",
+      "filePath": "app/models/admin.rb",
+      "lineRange": [
+        3,
+        11
+      ],
+      "summary": "has_secure_password 기반 인증 자격을 가진 관리자 ActiveRecord 모델 클래스. SessionsController의 로그인 흐름에서 authenticate 대상이 된다.",
+      "tags": [
+        "data-model",
+        "authentication",
+        "active-record"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/models/application_record.rb",
+      "type": "file",
+      "name": "application_record.rb",
+      "filePath": "app/models/application_record.rb",
+      "summary": "모든 모델이 상속하는 추상 기본 클래스(primary_abstract_class) 정의 파일로, 앱 공통 모델 로직의 진입점 역할을 한다.",
+      "tags": [
+        "data-model",
+        "base-class",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:app/models/application_record.rb:ApplicationRecord",
+      "type": "class",
+      "name": "ApplicationRecord",
+      "filePath": "app/models/application_record.rb",
+      "lineRange": [
+        1,
+        3
+      ],
+      "summary": "ActiveRecord::Base를 상속하는 추상 모델 기본 클래스. Post, Admin, Tag 등 모든 도메인 모델의 공통 부모다.",
+      "tags": [
+        "base-class",
+        "active-record",
+        "abstract"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/models/concerns/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "app/models/concerns/.keep",
+      "summary": "빈 app/models/concerns 디렉터리를 git이 추적하도록 유지하는 0바이트 placeholder 파일이다.",
+      "tags": [
+        "placeholder",
+        "git",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/models/tag.rb",
+      "type": "file",
+      "name": "tag.rb",
+      "filePath": "app/models/tag.rb",
+      "summary": "게시글 태그 모델. 저장 전 이름을 소문자 트림 정규화하고, 게시글 수 기준 인기 태그 집계(popular_with_counts)와 이름 기반 find-or-create 헬퍼를 제공한다.",
+      "tags": [
+        "data-model",
+        "tag",
+        "aggregation",
+        "normalization",
+        "tested"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:app/models/tag.rb:Tag",
+      "type": "class",
+      "name": "Tag",
+      "filePath": "app/models/tag.rb",
+      "lineRange": [
+        1,
+        29
+      ],
+      "summary": "posts와 다대다 관계를 맺는 태그 ActiveRecord 모델 클래스로, normalize_name 콜백과 두 개의 클래스 메서드로 태그 생성·집계 로직을 캡슐화한다.",
+      "tags": [
+        "data-model",
+        "active-record",
+        "many-to-many"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/tag.rb:popular_with_counts",
+      "type": "function",
+      "name": "self.popular_with_counts",
+      "filePath": "app/models/tag.rb",
+      "lineRange": [
+        12,
+        18
+      ],
+      "summary": "posts 조인 후 태그별 게시글 수를 COUNT로 집계해 인기순으로 [이름, 개수] 쌍을 반환하는 클래스 메서드. Arel.sql로 정렬식을 안전하게 전달한다.",
+      "tags": [
+        "aggregation",
+        "query",
+        "class-method"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/tag.rb:find_or_create_by_name",
+      "type": "function",
+      "name": "self.find_or_create_by_name",
+      "filePath": "app/models/tag.rb",
+      "lineRange": [
+        20,
+        22
+      ],
+      "summary": "이름을 트림·소문자화해 find_or_create_by로 태그를 조회하거나 생성하는 클래스 메서드로, Post#tag_list= 의 태그 파싱에서 사용된다.",
+      "tags": [
+        "factory",
+        "finder",
+        "class-method"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/active_storage/blobs/_blob.html.erb",
+      "type": "file",
+      "name": "_blob.html.erb",
+      "filePath": "app/views/active_storage/blobs/_blob.html.erb",
+      "summary": "Action Text 첨부 blob을 렌더링하는 Active Storage 오버라이드 partial. representable한 blob은 갤러리 여부에 따라 800x600 또는 1024x768로 리사이즈한 이미지를 출력하고, 캡션이 없으면 파일명과 크기를 표시한다.",
+      "tags": [
+        "view",
+        "partial",
+        "active-storage",
+        "attachment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/errors/internal_server.html.erb",
+      "type": "file",
+      "name": "internal_server.html.erb",
+      "filePath": "app/views/errors/internal_server.html.erb",
+      "summary": "500 Internal Server Error 커스텀 에러 페이지로 사과 메시지와 홈으로 돌아가기 링크를 제공한다.",
+      "tags": [
+        "view",
+        "error-page",
+        "500"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/errors/not_found.html.erb",
+      "type": "file",
+      "name": "not_found.html.erb",
+      "filePath": "app/views/errors/not_found.html.erb",
+      "summary": "404 Not Found 커스텀 에러 페이지. 안내 문구와 함께 검색 폼과 @all_tags 기반 태그 탐색 링크를 제공해 방문자가 다른 콘텐츠로 이동하도록 돕는다.",
+      "tags": [
+        "view",
+        "error-page",
+        "404",
+        "검색"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/errors/unprocessable.html.erb",
+      "type": "file",
+      "name": "unprocessable.html.erb",
+      "filePath": "app/views/errors/unprocessable.html.erb",
+      "summary": "422 Unprocessable Entity 커스텀 에러 페이지로 요청 거부 안내와 홈 링크를 제공한다.",
+      "tags": [
+        "view",
+        "error-page",
+        "422"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/kaminari/_gap.html.erb",
+      "type": "file",
+      "name": "_gap.html.erb",
+      "filePath": "app/views/kaminari/_gap.html.erb",
+      "summary": "Kaminari 페이지네이션에서 생략된 페이지 구간을 말줄임표(…)로 표시하는 테마 오버라이드 partial이다.",
+      "tags": [
+        "view",
+        "partial",
+        "pagination",
+        "kaminari"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/kaminari/_next_page.html.erb",
+      "type": "file",
+      "name": "_next_page.html.erb",
+      "filePath": "app/views/kaminari/_next_page.html.erb",
+      "summary": "Kaminari '다음 페이지' 링크 partial. 필터 없는 posts#index에서는 SEO 친화적인 posts_page_path 정적 경로로 URL을 교체하고, data-turbo=false로 전체 페이지 로드를 강제한다.",
+      "tags": [
+        "view",
+        "partial",
+        "pagination",
+        "seo"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/kaminari/_page.html.erb",
+      "type": "file",
+      "name": "_page.html.erb",
+      "filePath": "app/views/kaminari/_page.html.erb",
+      "summary": "Kaminari 페이지네이션의 개별 페이지 번호 링크를 렌더링하는 partial입니다. posts#index 기본 목록에서는 필터 파라미터가 없을 때 SEO 친화적인 posts_page_path(/posts/page/:page) 경로로 URL을 재작성합니다.",
+      "tags": [
+        "pagination",
+        "partial",
+        "view-template",
+        "kaminari"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Kaminari gem의 기본 테마 템플릿을 app/views/kaminari/에 복사해 오버라이드하는 Rails 관례를 따르며, 컨트롤러/액션 컨텍스트에 따라 링크 URL을 조건부로 바꾸는 커스터마이징이 적용되어 있습니다."
+    },
+    {
+      "id": "file:app/views/kaminari/_paginator.html.erb",
+      "type": "file",
+      "name": "_paginator.html.erb",
+      "filePath": "app/views/kaminari/_paginator.html.erb",
+      "summary": "Kaminari 페이지네이션 전체 컨테이너 partial로, 이전 페이지·페이지 번호·다음 페이지 태그를 조합해 aria 레이블과 스크린리더 텍스트를 갖춘 접근성 있는 내비게이션 마크업을 생성합니다.",
+      "tags": [
+        "pagination",
+        "partial",
+        "view-template",
+        "accessibility",
+        "kaminari"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/kaminari/_prev_page.html.erb",
+      "type": "file",
+      "name": "_prev_page.html.erb",
+      "filePath": "app/views/kaminari/_prev_page.html.erb",
+      "summary": "Kaminari 페이지네이션의 'Previous' 링크 partial로 SVG 화살표 아이콘을 포함하며, posts#index 기본 목록에서는 posts_page_path 기반의 정적 경로로 URL을 재작성합니다.",
+      "tags": [
+        "pagination",
+        "partial",
+        "view-template",
+        "kaminari"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/layouts/action_text/contents/_content.html.erb",
+      "type": "file",
+      "name": "_content.html.erb",
+      "filePath": "app/views/layouts/action_text/contents/_content.html.erb",
+      "summary": "Action Text 리치 텍스트 콘텐츠를 감싸는 레이아웃 partial로, 별도 래퍼 마크업 없이 yield만 수행하는 최소 구현입니다.",
+      "tags": [
+        "action-text",
+        "layout",
+        "partial",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/layouts/mailer.html.erb",
+      "type": "file",
+      "name": "mailer.html.erb",
+      "filePath": "app/views/layouts/mailer.html.erb",
+      "summary": "Action Mailer HTML 이메일의 기본 레이아웃으로, 인라인 스타일 자리 표시자와 함께 메일 본문을 yield로 감쌉니다. Rails 기본 생성 코드에서 수정되지 않은 상태입니다.",
+      "tags": [
+        "mailer",
+        "layout",
+        "boilerplate",
+        "view-template"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/layouts/mailer.text.erb",
+      "type": "file",
+      "name": "mailer.text.erb",
+      "filePath": "app/views/layouts/mailer.text.erb",
+      "summary": "텍스트 형식 이메일용 레이아웃으로 본문을 yield만 하는 한 줄짜리 Rails 기본 템플릿입니다.",
+      "tags": [
+        "mailer",
+        "layout",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/_post.html.erb",
+      "type": "file",
+      "name": "_post.html.erb",
+      "filePath": "app/views/posts/_post.html.erb",
+      "summary": "게시글의 제목·요약·게시일을 단순 표시하는 스캐폴드 기본 partial로, 커스텀 뷰들이 별도 마크업을 쓰기 때문에 실사용 빈도는 낮습니다.",
+      "tags": [
+        "partial",
+        "scaffold",
+        "boilerplate",
+        "view-template"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/_post_card.html.erb",
+      "type": "file",
+      "name": "_post_card.html.erb",
+      "filePath": "app/views/posts/_post_card.html.erb",
+      "summary": "이전/다음 게시글 네비게이션에서 쓰이는 게시글 카드 partial로, truncate된 제목·요약과 post_meta, 반응형 썸네일(responsive_image_tag, lazy 로딩 옵션)을 렌더링합니다.",
+      "tags": [
+        "partial",
+        "component",
+        "view-template",
+        "responsive-image"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/_post_navigation.html.erb",
+      "type": "file",
+      "name": "_post_navigation.html.erb",
+      "filePath": "app/views/posts/_post_navigation.html.erb",
+      "summary": "게시글 상세 하단의 이전/다음 게시글 네비게이션 partial로, 추천 게시글 존재 여부에 따라 래퍼 스타일을 바꾸고 각 방향을 post_card partial로 렌더링합니다.",
+      "tags": [
+        "partial",
+        "navigation",
+        "component",
+        "view-template"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/_recommended_posts.html.erb",
+      "type": "file",
+      "name": "_recommended_posts.html.erb",
+      "filePath": "app/views/posts/_recommended_posts.html.erb",
+      "summary": "게시글 상세 하단의 'Recommended Reading' 섹션 partial로, 추천 게시글마다 최적화 썸네일(optimized_image_tag), 메타 정보, 제목 링크, 작성자 멘션을 카드 형태로 렌더링합니다.",
+      "tags": [
+        "partial",
+        "component",
+        "recommendation",
+        "view-template"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/_sidebar.html.erb",
+      "type": "file",
+      "name": "_sidebar.html.erb",
+      "filePath": "app/views/posts/_sidebar.html.erb",
+      "summary": "게시글 상세 페이지의 사이드바 partial로 검색 폼(search_path), 최근 게시글 목록, 연도별 아카이브(archive_posts_path) 위젯을 제공합니다.",
+      "tags": [
+        "partial",
+        "sidebar",
+        "search",
+        "widget",
+        "view-template"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:app/views/posts/edit.html.erb",
+      "type": "file",
+      "name": "edit.html.erb",
+      "filePath": "app/views/posts/edit.html.erb",
+      "summary": "게시글 수정 페이지 뷰로, 페이지 타이틀을 지정하고 'Editing Post' 헤더 아래에 공용 _form partial을 렌더링합니다.",
+      "tags": [
+        "view-template",
+        "crud",
+        "admin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/new.html.erb",
+      "type": "file",
+      "name": "new.html.erb",
+      "filePath": "app/views/posts/new.html.erb",
+      "summary": "새 게시글 작성 페이지 뷰로, 페이지 타이틀을 지정하고 'New Post' 헤더 아래에 공용 _form partial을 렌더링합니다.",
+      "tags": [
+        "view-template",
+        "crud",
+        "admin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/posts/show_all.html.erb",
+      "type": "file",
+      "name": "show_all.html.erb",
+      "filePath": "app/views/posts/show_all.html.erb",
+      "summary": "전체 목록·연도별 아카이브·태그·카테고리·검색 결과를 하나로 처리하는 게시글 목록 뷰입니다. 컨텍스트별로 타이틀과 헤더를 분기하고, 검색 결과가 없으면 재검색 폼과 인기 태그 상위 10개를 제안하며, Kaminari 페이지네이션을 사용합니다.",
+      "tags": [
+        "view-template",
+        "list-page",
+        "search",
+        "pagination",
+        "archive"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "빈 검색 결과 분기에서 뷰가 직접 Tag.joins(:posts) 집계 쿼리를 실행하는데, 이는 컨트롤러/모델로 옮기는 것이 Rails 관례에 더 부합하는 패턴입니다."
+    },
+    {
+      "id": "file:app/views/pwa/manifest.json.erb",
+      "type": "file",
+      "name": "manifest.json.erb",
+      "filePath": "app/views/pwa/manifest.json.erb",
+      "summary": "PWA 웹 앱 manifest를 렌더링하는 ERB 템플릿으로 앱 이름, 512x512 아이콘(일반/maskable), standalone 디스플레이 모드, 테마·배경 색상을 정의합니다.",
+      "tags": [
+        "pwa",
+        "manifest",
+        "view-template",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/pwa/service-worker.js",
+      "type": "file",
+      "name": "service-worker.js",
+      "filePath": "app/views/pwa/service-worker.js",
+      "summary": "Web Push 알림 처리를 위한 service worker 스켈레톤 파일로, push·notificationclick 이벤트 핸들러 예시가 전부 주석 처리되어 있어 현재는 동작 코드가 없습니다.",
+      "tags": [
+        "pwa",
+        "service-worker",
+        "boilerplate",
+        "web-push"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/sessions/new.html.erb",
+      "type": "file",
+      "name": "new.html.erb",
+      "filePath": "app/views/sessions/new.html.erb",
+      "summary": "관리자 로그인 페이지 뷰로, login_path로 POST하는 이메일/비밀번호 폼과 flash[:alert] 오류 메시지 표시를 인라인 스타일 기반으로 구성합니다.",
+      "tags": [
+        "view-template",
+        "authentication",
+        "form",
+        "admin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/brakeman",
+      "type": "file",
+      "name": "brakeman",
+      "filePath": "bin/brakeman",
+      "summary": "Brakeman 정적 보안 스캐너를 실행하는 binstub으로, --ensure-latest 플래그를 자동으로 추가해 최신 버전 사용을 강제합니다.",
+      "tags": [
+        "binstub",
+        "security",
+        "static-analysis",
+        "tooling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/bundler-audit",
+      "type": "file",
+      "name": "bundler-audit",
+      "filePath": "bin/bundler-audit",
+      "summary": "bundler-audit CLI를 실행하는 binstub으로, 인자가 없거나 check 명령일 때 config/bundler-audit.yml 설정 파일을 자동으로 적용해 Gemfile.lock의 취약 gem을 검사합니다.",
+      "tags": [
+        "binstub",
+        "security",
+        "dependency-audit",
+        "tooling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/check-code",
+      "type": "file",
+      "name": "check-code",
+      "filePath": "bin/check-code",
+      "summary": "커밋 전 코드 품질 검사를 일괄 수행하는 bash 스크립트로, Brakeman 보안 스캔 → RuboCop 린트 → Rails 단위/시스템 테스트를 순차 실행하고 하나라도 실패하면 즉시 중단합니다.",
+      "tags": [
+        "script",
+        "ci-cd",
+        "quality-gate",
+        "tooling"
+      ],
+      "complexity": "simple",
+      "languageNotes": "set -e와 단계별 if ! ... 분기를 함께 사용해 각 실패 지점마다 맞춤 오류 메시지를 출력하는 pre-commit 스타일 게이트 스크립트입니다."
+    },
+    {
+      "id": "file:bin/ci",
+      "type": "file",
+      "name": "ci",
+      "filePath": "bin/ci",
+      "summary": "Rails 8의 ActiveSupport::ContinuousIntegration을 로드한 뒤 config/ci.rb에 정의된 CI 파이프라인을 실행하는 binstub 스크립트.",
+      "tags": [
+        "ci-cd",
+        "entry-point",
+        "binstub",
+        "script"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/dev",
+      "type": "file",
+      "name": "dev",
+      "filePath": "bin/dev",
+      "summary": "foreman 설치를 확인하고 기본 포트 3000과 디버거 원격 접속 환경변수를 설정한 뒤 Procfile.dev 기반으로 개발 서버를 시작하는 셸 스크립트.",
+      "tags": [
+        "development",
+        "entry-point",
+        "script",
+        "process-manager"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/docker-entrypoint",
+      "type": "file",
+      "name": "docker-entrypoint",
+      "filePath": "bin/docker-entrypoint",
+      "summary": "Docker 컨테이너 시작 시 rails server 실행이 감지되면 db:prepare로 데이터베이스를 생성·마이그레이션한 뒤 전달받은 명령을 exec하는 컨테이너 엔트리포인트 스크립트.",
+      "tags": [
+        "containerization",
+        "entry-point",
+        "database",
+        "script"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/importmap",
+      "type": "file",
+      "name": "importmap",
+      "filePath": "bin/importmap",
+      "summary": "애플리케이션 설정을 로드한 뒤 importmap-rails 명령(pin, audit 등)을 실행할 수 있게 하는 binstub.",
+      "tags": [
+        "binstub",
+        "asset-management",
+        "javascript",
+        "cli"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/jobs",
+      "type": "file",
+      "name": "jobs",
+      "filePath": "bin/jobs",
+      "summary": "Rails 환경 전체를 로드하고 Solid Queue 백그라운드 잡 워커 CLI를 시작하는 binstub.",
+      "tags": [
+        "background-jobs",
+        "entry-point",
+        "binstub"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/kamal",
+      "type": "file",
+      "name": "kamal",
+      "filePath": "bin/kamal",
+      "summary": "Bundler가 생성한 Kamal 배포 도구 binstub으로, bin/bundle의 무결성을 검증한 뒤 kamal gem의 실행 파일을 로드한다.",
+      "tags": [
+        "deployment",
+        "binstub",
+        "infrastructure"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/rails",
+      "type": "file",
+      "name": "rails",
+      "filePath": "bin/rails",
+      "summary": "server, console, generate 등 Rails 명령행 인터페이스를 실행하는 표준 Rails binstub.",
+      "tags": [
+        "entry-point",
+        "binstub",
+        "cli"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/rake",
+      "type": "file",
+      "name": "rake",
+      "filePath": "bin/rake",
+      "summary": "부트스트랩 후 Rake 태스크 러너를 실행하는 표준 binstub.",
+      "tags": [
+        "binstub",
+        "build-system",
+        "cli"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/rubocop",
+      "type": "file",
+      "name": "rubocop",
+      "filePath": "bin/rubocop",
+      "summary": "프로젝트 루트의 .rubocop.yml 설정을 명시적으로 지정해 RuboCop 린터를 실행하는 binstub.",
+      "tags": [
+        "binstub",
+        "lint",
+        "code-quality"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:bin/setup",
+      "type": "file",
+      "name": "setup",
+      "filePath": "bin/setup",
+      "summary": "의존성 설치, 데이터베이스 준비, 로그·임시파일 정리를 수행하고 기본적으로 bin/dev를 exec해 개발 서버까지 시작하는 멱등성 개발 환경 셋업 스크립트.",
+      "tags": [
+        "development",
+        "setup",
+        "entry-point",
+        "script"
+      ],
+      "complexity": "simple",
+      "languageNotes": "system! 헬퍼로 각 셸 명령 실패 시 예외를 발생시켜 셋업 중단을 보장하는 Rails 관례 패턴이다."
+    },
+    {
+      "id": "file:bin/thrust",
+      "type": "file",
+      "name": "thrust",
+      "filePath": "bin/thrust",
+      "summary": "에셋 캐싱과 압축을 담당하는 Thruster HTTP 프록시 실행 파일을 로드하는 binstub.",
+      "tags": [
+        "binstub",
+        "http-proxy",
+        "deployment"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config.ru",
+      "type": "file",
+      "name": "config.ru",
+      "filePath": "config.ru",
+      "summary": "Rack 기반 서버(Puma 등)가 Rails 애플리케이션을 기동할 때 사용하는 표준 Rack 진입점.",
+      "tags": [
+        "entry-point",
+        "rack",
+        "server"
+      ],
+      "complexity": "simple",
+      "languageNotes": "config.ru는 Ruby Rack 규약 파일로, run Rails.application 한 줄로 Rack 호환 서버에 앱을 넘겨준다."
+    },
+    {
+      "id": "file:config/boot.rb",
+      "type": "file",
+      "name": "boot.rb",
+      "filePath": "config/boot.rb",
+      "summary": "Bundler로 Gemfile의 gem을 준비하고 bootsnap 캐시로 부팅 속도를 높이는 최초 부트스트랩 파일.",
+      "tags": [
+        "bootstrap",
+        "configuration",
+        "performance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/ci.rb",
+      "type": "file",
+      "name": "ci.rb",
+      "filePath": "config/ci.rb",
+      "summary": "bin/ci가 실행하는 CI 파이프라인 정의로 셋업, RuboCop 스타일 검사, 보안 감사(bundler-audit·importmap audit·Brakeman), Rails·시스템·시드 테스트 단계를 순서대로 선언한다.",
+      "tags": [
+        "ci-cd",
+        "security",
+        "test",
+        "pipeline-definition"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Rails 8의 ActiveSupport::ContinuousIntegration DSL(step)을 사용한 로컬 CI 정의 방식이다."
+    },
+    {
+      "id": "file:config/credentials.yml.enc",
+      "type": "file",
+      "name": "credentials.yml.enc",
+      "filePath": "config/credentials.yml.enc",
+      "summary": "master key로만 복호화할 수 있는 Rails 암호화 자격 증명 파일로, API 키 등 비밀 설정을 저장소에 안전하게 보관한다.",
+      "tags": [
+        "security",
+        "credentials",
+        "configuration"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/environment.rb",
+      "type": "file",
+      "name": "environment.rb",
+      "filePath": "config/environment.rb",
+      "summary": "애플리케이션 설정을 로드한 뒤 Rails.application.initialize!를 호출해 전체 initializer 체인을 실행하는 환경 초기화 진입 파일.",
+      "tags": [
+        "bootstrap",
+        "initialization",
+        "entry-point"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/environments/development.rb",
+      "type": "file",
+      "name": "development.rb",
+      "filePath": "config/environments/development.rb",
+      "summary": "코드 즉시 리로딩, tmp/caching-dev.txt로 토글하는 캐싱, 상세한 쿼리·리다이렉트·잡 로그 등 개발 환경 전용 Rails 설정.",
+      "tags": [
+        "configuration",
+        "development",
+        "caching",
+        "logging"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:config/environments/production.rb",
+      "type": "file",
+      "name": "production.rb",
+      "filePath": "config/environments/production.rb",
+      "summary": "프로덕션 환경 설정으로 1년 immutable 정적 에셋 캐시, Cloudflare Tunnel 뒤 assume_ssl·force_ssl, Solid Cache·Solid Queue 백엔드, ALLOWED_HOSTS 기반 Host Authorization(DNS rebinding 방어)을 구성한다.",
+      "tags": [
+        "configuration",
+        "production",
+        "security",
+        "caching",
+        "deployment"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Health check 경로 /up은 SSL 리다이렉트와 Host 검증에서 모두 제외해 프록시 헬스체크가 차단되지 않도록 했다."
+    },
+    {
+      "id": "file:config/initializers/action_text.rb",
+      "type": "file",
+      "name": "action_text.rb",
+      "filePath": "config/initializers/action_text.rb",
+      "summary": "Action Text HTML sanitizer 허용 목록을 확장해 TinyMCE 에디터가 생성하는 테이블 태그·속성, svg 태그, data-turbo 링크 속성을 허용하는 initializer.",
+      "tags": [
+        "configuration",
+        "sanitization",
+        "security",
+        "action-text"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Rails 7.1+에서는 allowed_tags/allowed_attributes 기본값이 nil이므로 nil 체크 후 safe_list_sanitizer 기본 목록에 합산하는 방어적 패턴을 사용한다."
+    },
+    {
+      "id": "file:config/initializers/assets.rb",
+      "type": "file",
+      "name": "assets.rb",
+      "filePath": "config/initializers/assets.rb",
+      "summary": "에셋 버전(1.0)을 지정해 필요 시 전체 에셋 캐시를 무효화할 수 있게 하는 asset pipeline 기본 initializer.",
+      "tags": [
+        "configuration",
+        "asset-management",
+        "caching"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/initializers/cloudflare.rb",
+      "type": "file",
+      "name": "cloudflare.rb",
+      "filePath": "config/initializers/cloudflare.rb",
+      "summary": "프로덕션에서 Cloudflare IPv4·IPv6 대역 전체를 신뢰 프록시로 등록해 ActionDispatch::RemoteIp가 실제 클라이언트 IP를 올바르게 인식하도록 하는 initializer.",
+      "tags": [
+        "configuration",
+        "security",
+        "networking",
+        "cloudflare"
+      ],
+      "complexity": "simple",
+      "languageNotes": "trusted_proxies에 Cloudflare 공식 IP 범위를 IPAddr로 추가하지 않으면 remote_ip가 프록시 IP로 기록되어 로그·rate limiting이 왜곡된다."
+    },
+    {
+      "id": "file:config/initializers/content_security_policy.rb",
+      "type": "file",
+      "name": "content_security_policy.rb",
+      "filePath": "config/initializers/content_security_policy.rb",
+      "summary": "XSS 공격 방어를 위한 Content Security Policy(CSP) 설정 initializer로, TinyMCE·jsdelivr CDN·Google Analytics·Cloudflare Insights 등 외부 리소스 출처를 허용 목록으로 관리합니다. 현재는 report-only 모드로 위반 사항을 모니터링만 하며 실제 차단은 하지 않습니다.",
+      "tags": [
+        "security",
+        "configuration",
+        "initializer",
+        "csp"
+      ],
+      "complexity": "simple",
+      "languageNotes": "TinyMCE가 내부적으로 eval을 사용하기 때문에 :unsafe_eval을 허용해야 하는 트레이드오프가 주석으로 명시되어 있습니다."
+    },
+    {
+      "id": "file:config/initializers/filter_parameter_logging.rb",
+      "type": "file",
+      "name": "filter_parameter_logging.rb",
+      "filePath": "config/initializers/filter_parameter_logging.rb",
+      "summary": "비밀번호, 이메일, 토큰 등 민감한 요청 파라미터가 로그 파일에 평문으로 기록되지 않도록 필터링 규칙을 정의하는 Rails 표준 initializer입니다.",
+      "tags": [
+        "security",
+        "configuration",
+        "logging",
+        "initializer"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/initializers/inflections.rb",
+      "type": "file",
+      "name": "inflections.rb",
+      "filePath": "config/initializers/inflections.rb",
+      "summary": "ActiveSupport 단수/복수 변환 규칙을 커스터마이징하는 initializer로, 현재는 모든 예시가 주석 처리된 Rails 기본 보일러플레이트 상태입니다.",
+      "tags": [
+        "configuration",
+        "initializer",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/initializers/kaminari_config.rb",
+      "type": "file",
+      "name": "kaminari_config.rb",
+      "filePath": "config/initializers/kaminari_config.rb",
+      "summary": "Kaminari 페이지네이션 gem의 전역 설정으로, 페이지당 8개 게시글 표시와 현재 페이지 양옆 1페이지만 노출하는 좁은 window 스타일을 지정합니다.",
+      "tags": [
+        "configuration",
+        "pagination",
+        "initializer"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/initializers/security_headers.rb",
+      "type": "file",
+      "name": "security_headers.rb",
+      "filePath": "config/initializers/security_headers.rb",
+      "summary": "프로덕션 환경에서만 HSTS, X-Frame-Options, Referrer-Policy, Permissions-Policy 등 추가 보안 HTTP 헤더를 기본 응답에 병합하는 initializer입니다. Cloudflare 설정과 중복되지만 이중 방어 목적으로 Rails 레벨에서도 적용합니다.",
+      "tags": [
+        "security",
+        "configuration",
+        "initializer",
+        "http-headers"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:config/locales/en.yml",
+      "type": "config",
+      "name": "en.yml",
+      "filePath": "config/locales/en.yml",
+      "summary": "Rails i18n 기본 영어 로케일 파일로, 사용법 안내 주석과 예시용 hello 키만 있는 기본 보일러플레이트 상태입니다.",
+      "tags": [
+        "configuration",
+        "i18n",
+        "localization",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/puma.rb",
+      "type": "file",
+      "name": "puma.rb",
+      "filePath": "config/puma.rb",
+      "summary": "Puma 웹 서버 설정으로, 프로덕션에서는 WEB_CONCURRENCY 기반 클러스터 모드(기본 워커 4개)와 preload_app을 활성화하고 개발에서는 단일 프로세스로 동작합니다. 워커 부팅/종료 시 ActiveRecord 연결을 재설정하며, 단일 서버 배포용으로 Puma 내부에서 Solid Queue supervisor를 실행하는 옵션도 지원합니다.",
+      "tags": [
+        "configuration",
+        "web-server",
+        "performance",
+        "deployment"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "preload_app!과 Copy-on-Write를 활용한 메모리 효율화, on_worker_boot에서의 DB 연결 재수립은 Puma 클러스터 모드의 표준 패턴입니다."
+    },
+    {
+      "id": "file:db/cable_schema.rb",
+      "type": "file",
+      "name": "cable_schema.rb",
+      "filePath": "db/cable_schema.rb",
+      "summary": "Solid Cable(DB 기반 Action Cable 어댑터)이 사용하는 solid_cable_messages 테이블 스키마 정의로, 채널 해시와 payload를 저장해 WebSocket 메시지를 브로드캐스트합니다.",
+      "tags": [
+        "database",
+        "schema-definition",
+        "actioncable",
+        "solid-cable"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/cache_schema.rb",
+      "type": "file",
+      "name": "cache_schema.rb",
+      "filePath": "db/cache_schema.rb",
+      "summary": "Solid Cache(DB 기반 Rails 캐시 스토어)가 사용하는 solid_cache_entries 테이블 스키마 정의로, key_hash 유니크 인덱스와 byte_size 기반 용량 관리 인덱스를 포함합니다.",
+      "tags": [
+        "database",
+        "schema-definition",
+        "cache",
+        "solid-cache"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20251122082531_create_posts.rb",
+      "type": "file",
+      "name": "20251122082531_create_posts.rb",
+      "filePath": "db/migrate/20251122082531_create_posts.rb",
+      "summary": "블로그의 핵심 테이블인 posts를 생성하는 최초 마이그레이션으로, 제목·요약·작성자·발행일시 컬럼을 정의합니다.",
+      "tags": [
+        "migration",
+        "database",
+        "posts"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20251122082531_create_posts.rb:CreatePosts",
+      "type": "class",
+      "name": "CreatePosts",
+      "filePath": "db/migrate/20251122082531_create_posts.rb",
+      "lineRange": [
+        1,
+        12
+      ],
+      "summary": "posts 테이블(title, summary, author, published_at)을 생성하는 ActiveRecord 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "schema-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+      "type": "file",
+      "name": "20251122082559_create_active_storage_tables.active_storage.rb",
+      "filePath": "db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+      "summary": "Active Storage 파일 첨부 기능에 필요한 blobs·attachments·variant_records 세 테이블을 생성하는 Rails 엔진 제공 마이그레이션입니다. 커버 이미지와 본문 이미지 업로드의 기반이 됩니다.",
+      "tags": [
+        "migration",
+        "database",
+        "active-storage",
+        "file-upload"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb:CreateActiveStorageTables",
+      "type": "class",
+      "name": "CreateActiveStorageTables",
+      "filePath": "db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+      "lineRange": [
+        2,
+        57
+      ],
+      "summary": "active_storage_blobs, active_storage_attachments, active_storage_variant_records 테이블과 외래 키를 생성하며, 앱 generator 설정에서 기본 키 타입을 읽어오는 헬퍼 메서드를 포함합니다.",
+      "tags": [
+        "migration",
+        "database",
+        "active-storage"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+      "type": "file",
+      "name": "20251122082560_create_action_text_tables.action_text.rb",
+      "filePath": "db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+      "summary": "Action Text 리치 텍스트 본문을 저장하는 action_text_rich_texts 테이블을 생성하는 Rails 엔진 제공 마이그레이션으로, 게시글 본문(content)이 이 테이블에 폴리모픽으로 저장됩니다.",
+      "tags": [
+        "migration",
+        "database",
+        "action-text",
+        "rich-text"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20251122082560_create_action_text_tables.action_text.rb:CreateActionTextTables",
+      "type": "class",
+      "name": "CreateActionTextTables",
+      "filePath": "db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+      "lineRange": [
+        2,
+        26
+      ],
+      "summary": "record_type/record_id 폴리모픽 참조와 유니크 인덱스를 갖는 action_text_rich_texts 테이블을 생성하는 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "action-text"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20251125033932_add_tags_to_posts.rb",
+      "type": "file",
+      "name": "20251125033932_add_tags_to_posts.rb",
+      "filePath": "db/migrate/20251125033932_add_tags_to_posts.rb",
+      "summary": "posts 테이블에 쉼표 구분 문자열 방식의 tags 컬럼을 추가한 초기 태그 구현 마이그레이션으로, 이후 정규화된 tags 테이블 구조로 대체되었습니다.",
+      "tags": [
+        "migration",
+        "database",
+        "tags",
+        "deprecated"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20251125033932_add_tags_to_posts.rb:AddTagsToPosts",
+      "type": "class",
+      "name": "AddTagsToPosts",
+      "filePath": "db/migrate/20251125033932_add_tags_to_posts.rb",
+      "lineRange": [
+        1,
+        5
+      ],
+      "summary": "posts 테이블에 문자열 tags 컬럼을 추가하는 단일 add_column 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "tags"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+      "type": "file",
+      "name": "20251130051704_add_slug_and_category_to_posts.rb",
+      "filePath": "db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+      "summary": "SEO 친화적 URL을 위한 slug 컬럼(유니크 인덱스)과 게시글 분류용 category 컬럼(인덱스)을 posts 테이블에 추가하는 마이그레이션입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "seo",
+        "indexing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20251130051704_add_slug_and_category_to_posts.rb:AddSlugAndCategoryToPosts",
+      "type": "class",
+      "name": "AddSlugAndCategoryToPosts",
+      "filePath": "db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+      "lineRange": [
+        1,
+        8
+      ],
+      "summary": "slug(유니크)와 category 컬럼 및 각각의 인덱스를 posts에 추가하는 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "indexing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "type": "file",
+      "name": "20260319025507_create_tags_and_posts_tags.rb",
+      "filePath": "db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "summary": "문자열 태그를 정규화하기 위해 tags 테이블(이름 유니크)과 posts_tags 다대다 조인 테이블을 생성하는 마이그레이션으로, 태그 시스템 리팩토링의 첫 단계입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "tags",
+        "normalization",
+        "many-to-many"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20260319025507_create_tags_and_posts_tags.rb:CreateTagsAndPostsTags",
+      "type": "class",
+      "name": "CreateTagsAndPostsTags",
+      "filePath": "db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "lineRange": [
+        1,
+        15
+      ],
+      "summary": "tags 테이블과 id 없는 posts_tags 조인 테이블을 생성하고 (post_id, tag_id) 복합 유니크 인덱스를 추가하는 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "many-to-many"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "type": "file",
+      "name": "20260319034444_remove_tags_string_from_posts.rb",
+      "filePath": "db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "summary": "태그 정규화 완료 후 더 이상 사용하지 않는 posts.tags 문자열 컬럼을 제거하는 마이그레이션으로, 반드시 tags:migrate rake task 실행 이후에 적용해야 합니다.",
+      "tags": [
+        "migration",
+        "database",
+        "tags",
+        "cleanup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20260319034444_remove_tags_string_from_posts.rb:RemoveTagsStringFromPosts",
+      "type": "class",
+      "name": "RemoveTagsStringFromPosts",
+      "filePath": "db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "lineRange": [
+        1,
+        5
+      ],
+      "summary": "posts 테이블에서 레거시 tags 문자열 컬럼을 제거하는 단일 remove_column 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "cleanup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20260324033356_create_admins.rb",
+      "type": "file",
+      "name": "20260324033356_create_admins.rb",
+      "filePath": "db/migrate/20260324033356_create_admins.rb",
+      "summary": "관리자 인증을 위한 admins 테이블을 생성하는 마이그레이션으로, 이메일 유니크 인덱스와 has_secure_password용 password_digest 컬럼을 정의합니다.",
+      "tags": [
+        "migration",
+        "database",
+        "authentication",
+        "admin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20260324033356_create_admins.rb:CreateAdmins",
+      "type": "class",
+      "name": "CreateAdmins",
+      "filePath": "db/migrate/20260324033356_create_admins.rb",
+      "lineRange": [
+        1,
+        12
+      ],
+      "summary": "email(유니크 인덱스)과 password_digest 컬럼을 가진 admins 테이블을 생성하는 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "authentication"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+      "type": "file",
+      "name": "20260731120000_add_published_at_index_to_posts.rb",
+      "filePath": "db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+      "summary": "게시글 목록·아카이브 조회 성능 개선을 위해 posts.published_at 컬럼에 인덱스를 추가하는 성능 최적화 마이그레이션입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "performance",
+        "indexing"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20260731120000_add_published_at_index_to_posts.rb:AddPublishedAtIndexToPosts",
+      "type": "class",
+      "name": "AddPublishedAtIndexToPosts",
+      "filePath": "db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+      "lineRange": [
+        1,
+        7
+      ],
+      "summary": "posts.published_at에 인덱스를 추가하는 단일 add_index 마이그레이션 클래스입니다.",
+      "tags": [
+        "migration",
+        "database",
+        "performance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:db/queue_schema.rb",
+      "type": "file",
+      "name": "queue_schema.rb",
+      "filePath": "db/queue_schema.rb",
+      "summary": "Solid Queue 백그라운드 잡 시스템이 사용하는 전용 스키마 정의로, jobs·ready/claimed/blocked/failed/scheduled/recurring executions·processes·pauses·semaphores 등 잡 생명주기 전반을 관리하는 테이블들을 포함합니다.",
+      "tags": [
+        "database",
+        "schema-definition",
+        "background-jobs",
+        "solid-queue"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Rails 8의 Solid Queue는 Redis 없이 DB 테이블만으로 잡 큐를 구현하며, 실행 상태별로 테이블을 분리해 폴링 성능을 확보하는 구조입니다."
+    },
+    {
+      "id": "file:db/seeds.rb",
+      "type": "file",
+      "name": "seeds.rb",
+      "filePath": "db/seeds.rb",
+      "summary": "관리자 계정과 개발용 샘플 데이터를 생성하는 시드 스크립트로, 프로덕션에서는 ADMIN_EMAIL/ADMIN_PASSWORD 환경변수가 없으면 기본 자격증명 계정 생성을 차단하기 위해 예외를 발생시킵니다. 개발 환경에서는 태그·카테고리·커버 이미지가 첨부된 게시글 20개를 생성합니다.",
+      "tags": [
+        "seed-data",
+        "database",
+        "bootstrap",
+        "security"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "db:prepare가 시드를 자동 실행하는 점을 고려해, 프로덕션에서 기본 비밀번호 관리자 계정이 만들어지는 사고를 fail-fast 가드로 방지하는 패턴이 적용되어 있습니다."
+    },
+    {
+      "id": "file:lib/tasks/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "lib/tasks/.keep",
+      "summary": "빈 디렉터리가 git에 유지되도록 하는 0바이트 플레이스홀더 파일입니다.",
+      "tags": [
+        "placeholder",
+        "git-keep",
+        "boilerplate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:lib/tasks/import_from_sqlite.rake",
+      "type": "file",
+      "name": "import_from_sqlite.rake",
+      "filePath": "lib/tasks/import_from_sqlite.rake",
+      "summary": "SQLite 백업 파일의 데이터를 Supabase PostgreSQL로 이전하는 import:all rake task로, blobs → attachments → variants → posts → rich_texts → tags 순서로 원본 ID를 보존하며 복사해 Action Text 내부의 sgid 참조가 깨지지 않도록 합니다. 이전 결과를 점검하는 import:verify task와 PostgreSQL 시퀀스 재설정 헬퍼도 포함합니다.",
+      "tags": [
+        "rake-task",
+        "data-migration",
+        "database",
+        "etl",
+        "postgresql"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "ON CONFLICT DO NOTHING으로 멱등성을 보장하고, ID 보존 삽입 후 pg_get_serial_sequence 기반 setval로 시퀀스를 맞추는 것이 PostgreSQL 명시적 ID 삽입의 핵심 패턴입니다."
+    },
+    {
+      "id": "file:lib/tasks/migrate_tags.rake",
+      "type": "file",
+      "name": "migrate_tags.rake",
+      "filePath": "lib/tasks/migrate_tags.rake",
+      "summary": "쉼표 구분 문자열이던 posts.tags를 정규화된 Tag 레코드와 posts_tags 연관으로 변환하는 tags:migrate task와 변환 누락을 검증하는 tags:verify task를 제공합니다. RemoveTagsStringFromPosts 마이그레이션 적용 전에 실행해야 하며, 컬럼 존재 여부를 검사해 순서 위반 시 즉시 중단합니다.",
+      "tags": [
+        "rake-task",
+        "data-migration",
+        "tags",
+        "normalization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:script/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "script/.keep",
+      "summary": "Git이 빈 script 디렉터리를 버전 관리에 포함시키기 위한 0바이트 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/application_system_test_case.rb",
+      "type": "file",
+      "name": "application_system_test_case.rb",
+      "filePath": "test/application_system_test_case.rb",
+      "summary": "Selenium headless Chrome 드라이버와 1400x1400 화면 크기로 시스템 테스트의 공통 기반 클래스를 정의하는 파일.",
+      "tags": [
+        "test",
+        "system-test",
+        "selenium",
+        "base-class"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:test/application_system_test_case.rb:ApplicationSystemTestCase",
+      "type": "class",
+      "name": "ApplicationSystemTestCase",
+      "filePath": "test/application_system_test_case.rb",
+      "lineRange": [
+        3,
+        5
+      ],
+      "summary": "ActionDispatch::SystemTestCase를 상속해 headless_chrome 드라이버를 지정하는 시스템 테스트 공통 부모 클래스.",
+      "tags": [
+        "test",
+        "system-test",
+        "base-class"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/controllers/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/controllers/.keep",
+      "summary": "Git이 test/controllers 디렉터리를 버전 관리에 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/controllers/errors_controller_test.rb",
+      "type": "file",
+      "name": "errors_controller_test.rb",
+      "filePath": "test/controllers/errors_controller_test.rb",
+      "summary": "커스텀 404/422/500 에러 페이지가 오류 없이 렌더링되는지와 404 페이지의 인기 태그 노출을 검증하는 통합 테스트.",
+      "tags": [
+        "test",
+        "integration-test",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:test/controllers/errors_controller_test.rb:ErrorsControllerTest",
+      "type": "class",
+      "name": "ErrorsControllerTest",
+      "filePath": "test/controllers/errors_controller_test.rb",
+      "lineRange": [
+        3,
+        27
+      ],
+      "summary": "정적 에러 경로(/404, /422, /500)에 GET 요청을 보내 성공 응답과 태그·게시글이 있는 상태의 404 렌더링을 검증하는 테스트 케이스.",
+      "tags": [
+        "test",
+        "integration-test",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:test/fixtures/action_text/rich_texts.yml",
+      "type": "config",
+      "name": "rich_texts.yml",
+      "filePath": "test/fixtures/action_text/rich_texts.yml",
+      "summary": "Action Text 리치 텍스트 fixture의 주석 처리된 스캐폴드로, 실제 fixture 데이터는 정의되어 있지 않다.",
+      "tags": [
+        "test",
+        "fixture",
+        "action-text",
+        "scaffold"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:test/fixtures/admins.yml",
+      "type": "config",
+      "name": "admins.yml",
+      "filePath": "test/fixtures/admins.yml",
+      "summary": "BCrypt로 해시된 비밀번호('password')를 가진 관리자 계정(admin@example.com) 1건을 정의하는 테스트 fixture.",
+      "tags": [
+        "test",
+        "fixture",
+        "authentication"
+      ],
+      "complexity": "simple",
+      "languageNotes": "fixture 파일 안에서 ERB(<%= BCrypt::Password.create('password') %>)를 사용해 로드 시점에 동적으로 password_digest를 생성하는 Rails fixture 패턴."
+    },
+    {
+      "id": "file:test/fixtures/files/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/fixtures/files/.keep",
+      "summary": "file_fixture용 test/fixtures/files 디렉터리를 Git이 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "config:test/fixtures/posts.yml",
+      "type": "config",
+      "name": "posts.yml",
+      "filePath": "test/fixtures/posts.yml",
+      "summary": "Tech/Life 카테고리의 게시글 2건(slug, summary, published_at 포함)을 정의하는 Post 모델 테스트 fixture.",
+      "tags": [
+        "test",
+        "fixture",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/helpers/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/helpers/.keep",
+      "summary": "Git이 test/helpers 디렉터리를 버전 관리에 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/integration/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/integration/.keep",
+      "summary": "Git이 test/integration 디렉터리를 버전 관리에 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/mailers/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/mailers/.keep",
+      "summary": "Git이 test/mailers 디렉터리를 버전 관리에 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/models/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/models/.keep",
+      "summary": "Git이 test/models 디렉터리를 버전 관리에 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/models/tag_test.rb",
+      "type": "file",
+      "name": "tag_test.rb",
+      "filePath": "test/models/tag_test.rb",
+      "summary": "Tag 모델의 이름 정규화(소문자·공백 제거), 유일성·존재 검증, find_or_create_by_name, popular_with_counts의 게시글 수 기준 정렬을 검증하는 단위 테스트.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:test/models/tag_test.rb:TagTest",
+      "type": "class",
+      "name": "TagTest",
+      "filePath": "test/models/tag_test.rb",
+      "lineRange": [
+        3,
+        51
+      ],
+      "summary": "정규화·검증·find_or_create_by_name·인기 태그 집계 6개 시나리오로 Tag 모델을 검증하는 테스트 케이스.",
+      "tags": [
+        "test",
+        "unit-test",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/system/.keep",
+      "type": "file",
+      "name": ".keep",
+      "filePath": "test/system/.keep",
+      "summary": "Git이 test/system 디렉터리를 버전 관리에 유지하도록 하는 placeholder 파일.",
+      "tags": [
+        "placeholder",
+        "scaffold",
+        "빈-파일"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "pipeline:.github/workflows/ci.yml",
+      "type": "pipeline",
+      "name": "ci.yml",
+      "filePath": ".github/workflows/ci.yml",
+      "summary": "pull_request와 main 브랜치 push에서 실행되는 GitHub Actions CI 워크플로우로, Brakeman 보안 스캔·bundler-audit 취약점 점검·RuboCop 린트·전체 테스트(단위+시스템)를 4개의 독립 job으로 병렬 수행한다. 테스트 job은 libvips와 google-chrome-stable을 설치하고 실패 시 시스템 테스트 스크린샷을 아티팩트로 업로드한다.",
+      "tags": [
+        "ci-cd",
+        "infrastructure",
+        "security",
+        "testing",
+        "automation"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "네 job 모두 ruby/setup-ruby@v1 + bundler-cache로 의존성을 캐시하고 .ruby-version 파일에서 루비 버전을 읽는다. 테스트 job에만 libvips를 apt로 설치하는데, ruby-vips가 FFI로 libvips.so.42를 직접 로드하므로 없으면 앱 부팅 단계에서 Bundler::GemRequireError가 발생한다(Dockerfile과 동일 패키지). Redis 관련 services 블록은 주석 처리되어 현재 비활성 상태다."
+    },
+    {
+      "id": "file:app/assets/stylesheets/site.css",
+      "type": "file",
+      "name": "site.css",
+      "filePath": "app/assets/stylesheets/site.css",
+      "summary": "블로그 전역 스타일시트. 디자인 토큰(:root CSS 변수), 타이포그래피, 게시글 카드·본문·코드 블록, 다크 모드와 139개 미디어 쿼리 기반 반응형 레이아웃까지 사이트의 모든 시각적 규칙을 한 파일에 담고 있다.",
+      "tags": [
+        "stylesheet",
+        "design-system",
+        "responsive",
+        "theming",
+        "asset"
+      ],
+      "complexity": "complex",
+      "languageNotes": "6천 줄이 넘는 단일 CSS 번들로, 커스텀 프로퍼티(--color, --font-family-*)를 :root 에 선언해 테마 값을 중앙 집중 관리한다. Node 빌드 파이프라인 없이 그대로 서빙되므로 파일 분할 대신 단일 파일 + 섹션 주석 방식을 택했다."
+    },
+    {
+      "id": "file:app/controllers/application_controller.rb",
+      "type": "file",
+      "name": "application_controller.rb",
+      "filePath": "app/controllers/application_controller.rb",
+      "summary": "모든 컨트롤러의 기반 클래스로, 세션 기반 관리자 인증(12시간 타임아웃)과 HTML 응답의 Cache-Control 보정을 담당한다. admin_signed_in? 를 helper_method 로 노출해 뷰에서도 관리자 여부를 판단할 수 있게 한다.",
+      "tags": [
+        "controller",
+        "base-class",
+        "authentication",
+        "http-caching",
+        "middleware"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Rails 는 커밋 직전 handle_conditional_get! 에서 Cache-Control 이 비어 있을 때만 기본값을 채운다. after_action 은 그보다 먼저 돌기 때문에 헤더를 건드리면 기본값이 영영 적용되지 않아, CONDITIONAL_GET_CACHE_CONTROL 상수로 기본 지시자를 직접 포함시킨다."
+    },
+    {
+      "id": "file:app/controllers/posts_controller.rb",
+      "type": "file",
+      "name": "posts_controller.rb",
+      "filePath": "app/controllers/posts_controller.rb",
+      "summary": "게시글의 목록·검색·태그·연도별 아카이브·상세·CRUD 를 모두 처리하는 핵심 컨트롤러. post_scope 로 공개/비공개 가시성을 가르고, listing_scope 로 N+1 을 제거하며, 코드 블록 Base64 인코딩과 ETag 기반 HTTP 캐싱을 함께 관리한다.",
+      "tags": [
+        "controller",
+        "api-handler",
+        "crud",
+        "http-caching",
+        "pagination",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "index 의 ETag 는 relation 을 그대로 넘기지 않는다. Relation#cache_key 가 to_sql 다이제스트를 포함하는데 published 스코프의 Time.current 가 마이크로초까지 SQL 에 박혀 매 요청마다 ETag 가 달라지기 때문이다. 대신 cache_version(레코드 수 + 최신 updated_at)과 응답을 가르는 파라미터만 사용한다."
+    },
+    {
+      "id": "file:app/controllers/sessions_controller.rb",
+      "type": "file",
+      "name": "sessions_controller.rb",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "summary": "Devise 없이 구현한 관리자 로그인/로그아웃 컨트롤러. 서버 측 캐시에 IP 별 로그인 실패 횟수를 세어 5회/15분 브루트포스 잠금을 적용하고, 로그인 성공 시 카운터를 지운 뒤 reset_session 으로 세션 고정 공격을 막는다.",
+      "tags": [
+        "controller",
+        "authentication",
+        "security",
+        "rate-limiting",
+        "session",
+        "tested"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Rails 8 의 rate_limit 은 성공·실패를 가리지 않고 액션의 모든 요청을 세며 성공 시 초기화할 방법이 없어, 계정이 하나뿐인 이 블로그에서는 소유자가 정상 로그인만으로 자기 사이트에서 잠긴다. 그래서 Rails.cache.increment 로 실패만 세는 방식을 직접 구현했다."
+    },
+    {
+      "id": "file:app/controllers/uploads_controller.rb",
+      "type": "file",
+      "name": "uploads_controller.rb",
+      "filePath": "app/controllers/uploads_controller.rb",
+      "summary": "TinyMCE 에디터의 본문 이미지 업로드/삭제를 처리한다. MIME 타입과 10MB 크기를 검증한 뒤 Active Storage 블롭으로 저장하고, 7단계 variant 로 구성한 반응형 srcset 을 TinyMCE 가 기대하는 JSON 형식으로 돌려준다.",
+      "tags": [
+        "controller",
+        "api-handler",
+        "file-upload",
+        "validation",
+        "image-processing",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "URL 생성에 rails_blob_url 대신 polymorphic_path 를 쓴다. rails_blob_url 은 redirect 라우트로 고정돼 CDN 이 캐시할 수 없는 URL 을 만들지만, polymorphic_path 는 resolve_model_to_route 설정을 따라 커버 이미지와 동일한 proxy 경로를 생성한다."
+    },
+    {
+      "id": "file:app/helpers/application_helper.rb",
+      "type": "file",
+      "name": "application_helper.rb",
+      "filePath": "app/helpers/application_helper.rb",
+      "summary": "레이아웃이 Prism·Mermaid·MathJax 를 조건부로 로드하도록 돕는 뷰 헬퍼 모듈. 뷰에서 require_content_libraries 로 필요한 라이브러리를 표시하고, 게시글 HTML 을 분석해 실제로 쓰이는 라이브러리만 판별한다.",
+      "tags": [
+        "helper",
+        "view-layer",
+        "performance",
+        "conditional-loading",
+        "utility"
+      ],
+      "complexity": "simple",
+      "languageNotes": "CDN 라이브러리가 합쳐 수백 KB 이므로 content_for 플래그를 이용한 조건부 로딩으로 초기 로드를 줄인다. 판별이 애매하면 로드하는 쪽을 택한다 — 잘못 로드하면 느려질 뿐이지만 빠뜨리면 수식·다이어그램이 아예 렌더링되지 않기 때문이다."
+    },
+    {
+      "id": "class:app/controllers/application_controller.rb:ApplicationController",
+      "type": "class",
+      "name": "ApplicationController",
+      "filePath": "app/controllers/application_controller.rb",
+      "lineRange": [
+        1,
+        53
+      ],
+      "summary": "ActionController::Base 를 상속하는 애플리케이션 전역 기반 컨트롤러. 브라우저 지원 정책, importmap 변경 시 ETag 무효화, 관리자 인증 헬퍼, HTML 응답의 no-transform 캐시 지시자 부여를 모든 하위 컨트롤러에 제공한다.",
+      "tags": [
+        "controller",
+        "base-class",
+        "authentication",
+        "http-caching"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:app/controllers/posts_controller.rb:PostsController",
+      "type": "class",
+      "name": "PostsController",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        1,
+        167
+      ],
+      "summary": "게시글 관련 모든 HTTP 액션을 담은 컨트롤러. 쓰기 액션에는 authenticate_admin! 를, 조회 액션에는 set_post 를 before_action 으로 걸어 권한과 조회 스코프를 일관되게 강제한다.",
+      "tags": [
+        "controller",
+        "api-handler",
+        "crud",
+        "authorization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:app/controllers/sessions_controller.rb:SessionsController",
+      "type": "class",
+      "name": "SessionsController",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        3,
+        76
+      ],
+      "summary": "관리자 세션 생성·파기를 담당하는 컨트롤러. MAX_LOGIN_ATTEMPTS(5)와 LOCKOUT_DURATION(15분) 상수를 기준으로 캐시 기반 IP 별 실패 카운터를 운용한다.",
+      "tags": [
+        "controller",
+        "authentication",
+        "security",
+        "rate-limiting"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:app/controllers/uploads_controller.rb:UploadsController",
+      "type": "class",
+      "name": "UploadsController",
+      "filePath": "app/controllers/uploads_controller.rb",
+      "lineRange": [
+        5,
+        99
+      ],
+      "summary": "TinyMCE 이미지 업로드 전용 컨트롤러. 모든 액션에 authenticate_admin! 를 걸고, SRCSET_WIDTHS 상수(380~1280px)로 반응형 이미지 variant 목록을 정의한다.",
+      "tags": [
+        "controller",
+        "file-upload",
+        "image-processing",
+        "authorization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:app/helpers/application_helper.rb:ApplicationHelper",
+      "type": "class",
+      "name": "ApplicationHelper",
+      "filePath": "app/helpers/application_helper.rb",
+      "lineRange": [
+        1,
+        34
+      ],
+      "summary": "모든 뷰에 자동 포함되는 헬퍼 모듈. 콘텐츠 라이브러리(Prism/Mermaid/MathJax)의 필요 여부를 표시·조회·추론하는 네 개의 메서드를 제공한다.",
+      "tags": [
+        "helper",
+        "view-layer",
+        "module",
+        "conditional-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/application_controller.rb:set_no_transform_cache_control",
+      "type": "function",
+      "name": "set_no_transform_cache_control",
+      "filePath": "app/controllers/application_controller.rb",
+      "lineRange": [
+        23,
+        31
+      ],
+      "summary": "HTML 응답의 Cache-Control 헤더에 no-transform 지시자를 덧붙이는 after_action. 헤더가 비어 있으면 Rails 기본값(max-age=0, private, must-revalidate)을 직접 채워 넣어 캐시가 휴리스틱 신선도로 떨어지는 것을 막는다.",
+      "tags": [
+        "http-caching",
+        "after-action",
+        "header",
+        "workaround"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "function",
+      "name": "admin_signed_in?",
+      "filePath": "app/controllers/application_controller.rb",
+      "lineRange": [
+        35,
+        46
+      ],
+      "summary": "세션의 admin_id 유무와 12시간 타임아웃을 확인해 관리자 로그인 상태를 판정한다. 만료된 세션은 reset_session 으로 즉시 폐기하며, helper_method 로 뷰에서도 호출된다.",
+      "tags": [
+        "authentication",
+        "session",
+        "timeout",
+        "helper-method"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/application_controller.rb:authenticate_admin!",
+      "type": "function",
+      "name": "authenticate_admin!",
+      "filePath": "app/controllers/application_controller.rb",
+      "lineRange": [
+        48,
+        52
+      ],
+      "summary": "관리자가 아니면 로그인 페이지로 리다이렉트하는 인가 게이트. PostsController 의 쓰기 액션과 UploadsController 전체에 before_action 으로 걸린다.",
+      "tags": [
+        "authorization",
+        "before-action",
+        "security",
+        "guard"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:index",
+      "type": "function",
+      "name": "index",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        6,
+        34
+      ],
+      "summary": "게시글 목록을 발행일 역순으로 10개씩 페이지네이션해 반환한다. 관리자에게는 no-store 헤더를, 공개 요청에는 cache_version 과 파라미터로 만든 ETag 를 부여하고, page/category 파라미터가 있으면 show_all 템플릿으로 렌더링한다.",
+      "tags": [
+        "api-handler",
+        "pagination",
+        "http-caching",
+        "listing"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:search",
+      "type": "function",
+      "name": "search",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        37,
+        41
+      ],
+      "summary": "keyword 파라미터로 게시글을 검색해 최신순 8개씩 페이지네이션하고 show_all 템플릿으로 렌더링한다.",
+      "tags": [
+        "api-handler",
+        "search",
+        "pagination"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:archive",
+      "type": "function",
+      "name": "archive",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        44,
+        48
+      ],
+      "summary": "연도별 아카이브 액션. year 파라미터에 해당하는 게시글을 최신순 8개씩 보여준다.",
+      "tags": [
+        "api-handler",
+        "archive",
+        "pagination"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:tag",
+      "type": "function",
+      "name": "tag",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        51,
+        55
+      ],
+      "summary": "태그별 게시글 목록 액션. tag 파라미터로 필터링한 결과를 최신순 8개씩 보여준다.",
+      "tags": [
+        "api-handler",
+        "tagging",
+        "pagination"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:show",
+      "type": "function",
+      "name": "show",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        58,
+        75
+      ],
+      "summary": "게시글 상세 화면을 구성한다. 공개 요청에는 stale? 로 조건부 GET 을 처리하고, 최근 글·연도별 아카이브·이전/다음 글·같은 태그 추천 글(최대 3개)을 함께 로드한다.",
+      "tags": [
+        "api-handler",
+        "http-caching",
+        "detail-view",
+        "related-content"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:create",
+      "type": "function",
+      "name": "create",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        87,
+        95
+      ],
+      "summary": "허용된 파라미터로 새 게시글을 생성한다. 저장 성공 시 상세 페이지로 리다이렉트하고, 실패하면 422 상태로 new 템플릿을 다시 렌더링한다.",
+      "tags": [
+        "api-handler",
+        "crud",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:update",
+      "type": "function",
+      "name": "update",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        98,
+        104
+      ],
+      "summary": "기존 게시글을 수정한다. 성공 시 303 See Other 로 상세 페이지에 리다이렉트해 Turbo 의 폼 제출 흐름과 맞춘다.",
+      "tags": [
+        "api-handler",
+        "crud",
+        "turbo"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:destroy",
+      "type": "function",
+      "name": "destroy",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        107,
+        110
+      ],
+      "summary": "게시글을 삭제하고 목록으로 303 See Other 리다이렉트한다.",
+      "tags": [
+        "api-handler",
+        "crud",
+        "deletion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:set_post",
+      "type": "function",
+      "name": "set_post",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        115,
+        117
+      ],
+      "summary": "현재 스코프를 유지한 채 slug 또는 숫자 id 로 게시글을 조회하는 before_action. 영어 제목은 slug, 한국어 제목은 id 로 접근된다.",
+      "tags": [
+        "before-action",
+        "routing",
+        "slug",
+        "lookup"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:post_scope",
+      "type": "function",
+      "name": "post_scope",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        120,
+        122
+      ],
+      "summary": "가시성의 축이 되는 스코프 메서드. 관리자에게는 Post.all 을, 공개 요청에는 Post.published 를 반환해 예약 발행 글이 새어 나가지 않게 한다.",
+      "tags": [
+        "authorization",
+        "scope",
+        "visibility",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:listing_scope",
+      "type": "function",
+      "name": "listing_scope",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        130,
+        132
+      ],
+      "summary": "목록 카드가 쓰는 tags 와 cover_image 를 한 번에 적재해 N+1 을 제거한다. 본문(rich_text_content)은 posts.word_count 로 대체돼 더 이상 적재하지 않는다.",
+      "tags": [
+        "performance",
+        "eager-loading",
+        "scope",
+        "n-plus-one"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:post_params",
+      "type": "function",
+      "name": "post_params",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        141,
+        150
+      ],
+      "summary": "Strong Parameters 로 허용 필드를 걸러내고, content 가 있으면 encode_code_blocks 를 태워 코드 블록을 Base64 로 인코딩한 뒤 반환한다.",
+      "tags": [
+        "validation",
+        "strong-parameters",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:encode_code_blocks",
+      "type": "function",
+      "name": "encode_code_blocks",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        155,
+        166
+      ],
+      "summary": "pre/code 블록의 내용 전체를 Base64 로 치환해 Action Text(Nokogiri) sanitizer 가 HTML 엔티티를 실제 HTML 로 해석하는 것을 막는다. Base64 는 영숫자와 +/= 만 포함하므로 sanitizer 가 간섭할 수 없다.",
+      "tags": [
+        "serialization",
+        "sanitization",
+        "workaround",
+        "code-block"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        23,
+        27
+      ],
+      "summary": "로그인 폼을 표시한다. 이미 로그인한 관리자는 루트로 리다이렉트한다.",
+      "tags": [
+        "api-handler",
+        "authentication",
+        "form"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:create",
+      "type": "function",
+      "name": "create",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        29,
+        43
+      ],
+      "summary": "이메일로 관리자를 찾아 bcrypt 로 비밀번호를 검증한다. 성공하면 실패 카운터를 지우고 reset_session 후 세션에 admin_id 와 로그인 시각을 기록하며, 실패하면 남은 시도 횟수를 안내하고 422 를 반환한다.",
+      "tags": [
+        "api-handler",
+        "authentication",
+        "session",
+        "security"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:destroy",
+      "type": "function",
+      "name": "destroy",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        45,
+        48
+      ],
+      "summary": "reset_session 으로 로그아웃을 처리하고 루트 경로로 리다이렉트한다.",
+      "tags": [
+        "api-handler",
+        "authentication",
+        "session"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:reject_when_throttled",
+      "type": "function",
+      "name": "reject_when_throttled",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        52,
+        57
+      ],
+      "summary": "create 액션 진입 전 IP 별 실패 횟수를 확인해 5회 이상이면 429 Too Many Requests 로 로그인 폼을 다시 렌더링하는 before_action.",
+      "tags": [
+        "security",
+        "rate-limiting",
+        "before-action",
+        "guard"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:throttle_key",
+      "type": "function",
+      "name": "throttle_key",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        59,
+        61
+      ],
+      "summary": "실패 카운터의 캐시 키를 request.remote_ip 기준으로 생성한다. Cloudflare 대역이 trusted_proxies 로 등록돼 있어 실제 클라이언트 IP 로 해석된다.",
+      "tags": [
+        "security",
+        "rate-limiting",
+        "cache-key",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:failed_attempts",
+      "type": "function",
+      "name": "failed_attempts",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        63,
+        65
+      ],
+      "summary": "캐시에서 현재 IP 의 누적 로그인 실패 횟수를 읽어 정수로 반환한다.",
+      "tags": [
+        "security",
+        "rate-limiting",
+        "cache"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:record_failed_attempt",
+      "type": "function",
+      "name": "record_failed_attempt",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        69,
+        71
+      ],
+      "summary": "Rails.cache.increment 로 실패 횟수를 1 늘리고 15분 만료를 건다. 키가 없으면 amount 부터 시작하며, 창은 첫 실패 시점부터 고정이라 실패를 반복해도 무한히 연장되지 않는다.",
+      "tags": [
+        "security",
+        "rate-limiting",
+        "cache",
+        "counter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/sessions_controller.rb:clear_failed_attempts",
+      "type": "function",
+      "name": "clear_failed_attempts",
+      "filePath": "app/controllers/sessions_controller.rb",
+      "lineRange": [
+        73,
+        75
+      ],
+      "summary": "로그인 성공 시 해당 IP 의 실패 카운터를 캐시에서 삭제해, 정상 사용자가 자기 사이트에서 잠기지 않게 한다.",
+      "tags": [
+        "security",
+        "rate-limiting",
+        "cache",
+        "reset"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/uploads_controller.rb:image",
+      "type": "function",
+      "name": "image",
+      "filePath": "app/controllers/uploads_controller.rb",
+      "lineRange": [
+        13,
+        75
+      ],
+      "summary": "업로드 파일의 MIME 타입(JPEG/PNG/GIF/WEBP)과 10MB 크기 제한을 검증한 뒤 Active Storage 블롭으로 저장하고, 메타데이터에서 원본 크기를 얻어 원본보다 작은 폭만 골라 반응형 srcset 을 만들어 TinyMCE 형식의 JSON 으로 응답한다.",
+      "tags": [
+        "api-handler",
+        "file-upload",
+        "validation",
+        "image-processing",
+        "srcset"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/controllers/uploads_controller.rb:destroy_image",
+      "type": "function",
+      "name": "destroy_image",
+      "filePath": "app/controllers/uploads_controller.rb",
+      "lineRange": [
+        79,
+        98
+      ],
+      "summary": "src URL 에서 Active Storage signed_id 를 정규식으로 추출해 블롭을 purge 한다. 서명이 유효하지 않으면 조용히 무시하고 항상 200 을 반환한다.",
+      "tags": [
+        "api-handler",
+        "deletion",
+        "active-storage",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/helpers/application_helper.rb:require_content_libraries",
+      "type": "function",
+      "name": "require_content_libraries",
+      "filePath": "app/helpers/application_helper.rb",
+      "lineRange": [
+        5,
+        7
+      ],
+      "summary": "뷰에서 필요한 콘텐츠 라이브러리를 content_for(:needs_*) 플래그로 표시한다. 가변 인자를 flatten 해 배열과 개별 인자를 모두 받는다.",
+      "tags": [
+        "helper",
+        "view-layer",
+        "conditional-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/helpers/application_helper.rb:content_library?",
+      "type": "function",
+      "name": "content_library?",
+      "filePath": "app/helpers/application_helper.rb",
+      "lineRange": [
+        9,
+        11
+      ],
+      "summary": "레이아웃이 특정 라이브러리 로드 여부를 판단할 때 쓰는 조회 메서드. content_for? 로 플래그 존재를 확인한다.",
+      "tags": [
+        "helper",
+        "view-layer",
+        "conditional-loading",
+        "predicate"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/helpers/application_helper.rb:content_libraries_for",
+      "type": "function",
+      "name": "content_libraries_for",
+      "filePath": "app/helpers/application_helper.rb",
+      "lineRange": [
+        16,
+        23
+      ],
+      "summary": "게시글 본문 HTML 을 패턴 매칭해 필요한 라이브러리 심볼 배열(:prism, :mermaid, :mathjax)을 반환한다. 판별이 애매하면 로드하는 쪽으로 기운다.",
+      "tags": [
+        "helper",
+        "content-analysis",
+        "conditional-loading",
+        "performance"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/helpers/application_helper.rb:math_delimiters?",
+      "type": "function",
+      "name": "math_delimiters?",
+      "filePath": "app/helpers/application_helper.rb",
+      "lineRange": [
+        30,
+        33
+      ],
+      "summary": "MathJax 구분자가 본문에 있는지 검사한다. skipHtmlTags 대상인 pre/code 영역을 미리 제거해 셸 예제로 인한 오탐을 줄인다.",
+      "tags": [
+        "helper",
+        "content-analysis",
+        "regex",
+        "mathjax"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/helpers/image_helper.rb",
+      "type": "file",
+      "name": "image_helper.rb",
+      "filePath": "app/helpers/image_helper.rb",
+      "summary": "Active Storage 첨부 이미지를 WebP variant로 렌더링하는 뷰 헬퍼 모음으로, 사이즈 프리셋(:thumbnail~:hero)과 srcset/picture 태그 생성을 담당한다. blob 메타데이터에서 실제 표시 크기를 계산해 width/height를 채워 CLS를 줄인다.",
+      "tags": [
+        "helper",
+        "image-optimization",
+        "active-storage",
+        "view-layer",
+        "utility",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Rails 헬퍼 모듈은 뷰 컨텍스트에 믹스인되므로 image_tag/url_for 같은 Action View 헬퍼를 그대로 호출할 수 있다."
+    },
+    {
+      "id": "class:app/helpers/image_helper.rb:ImageHelper",
+      "type": "class",
+      "name": "ImageHelper",
+      "filePath": "app/helpers/image_helper.rb",
+      "lineRange": [
+        3,
+        155
+      ],
+      "summary": "이미지 사이즈 프리셋 상수(IMAGE_SIZES)와 최적화 이미지 태그 생성 메서드 4개를 제공하는 헬퍼 모듈이다.",
+      "tags": [
+        "helper",
+        "module",
+        "image-optimization",
+        "view-layer"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/helpers/image_helper.rb:optimized_image_tag",
+      "type": "function",
+      "name": "optimized_image_tag",
+      "filePath": "app/helpers/image_helper.rb",
+      "lineRange": [
+        17,
+        44
+      ],
+      "summary": "첨부 이미지를 지정 프리셋의 WebP variant로 변환해 img 태그를 만든다. lazy 로딩과 fetchpriority 옵션을 지원하며 intrinsic_dimensions로 실제 width/height를 세팅한다.",
+      "tags": [
+        "image-optimization",
+        "helper",
+        "lazy-loading",
+        "webp"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/helpers/image_helper.rb:responsive_image_tag",
+      "type": "function",
+      "name": "responsive_image_tag",
+      "filePath": "app/helpers/image_helper.rb",
+      "lineRange": [
+        52,
+        96
+      ],
+      "summary": "Active Storage 첨부와 정적 경로를 모두 받아 여러 폭의 variant URL로 srcset/sizes를 구성한 반응형 img 태그를 생성한다.",
+      "tags": [
+        "image-optimization",
+        "responsive",
+        "srcset",
+        "helper"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/helpers/image_helper.rb:picture_tag",
+      "type": "function",
+      "name": "picture_tag",
+      "filePath": "app/helpers/image_helper.rb",
+      "lineRange": [
+        102,
+        127
+      ],
+      "summary": "WebP source와 폴백 img를 묶은 <picture> 엘리먼트를 생성해 브라우저가 지원 포맷을 선택하도록 한다.",
+      "tags": [
+        "image-optimization",
+        "webp",
+        "helper",
+        "markup"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/helpers/image_helper.rb:intrinsic_dimensions",
+      "type": "function",
+      "name": "intrinsic_dimensions",
+      "filePath": "app/helpers/image_helper.rb",
+      "lineRange": [
+        140,
+        154
+      ],
+      "summary": "blob 메타데이터의 원본 width/height를 읽어 프리셋 한계 안에서 비율을 유지한 실제 표시 크기를 계산한다. 하드코딩된 고정 크기를 대체해 레이아웃 시프트를 방지한다.",
+      "tags": [
+        "image-optimization",
+        "metadata",
+        "layout-shift",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/javascript/application.js",
+      "type": "file",
+      "name": "application.js",
+      "filePath": "app/javascript/application.js",
+      "summary": "importmap 기반 프런트엔드 진입점으로 Turbo, Stimulus 컨트롤러, 커스텀 init 모듈을 로드한다. 에디터가 TinyMCE라 사용되지 않던 Trix/Action Text JS import는 제거되었다.",
+      "tags": [
+        "entry-point",
+        "importmap",
+        "hotwire",
+        "javascript"
+      ],
+      "complexity": "simple",
+      "languageNotes": "importmap-rails 환경이라 번들러 없이 베어 모듈 지정자(\"controllers\", \"init\")가 config/importmap.rb의 핀으로 해석된다."
+    },
+    {
+      "id": "file:app/models/post.rb",
+      "type": "file",
+      "name": "post.rb",
+      "filePath": "app/models/post.rb",
+      "summary": "블로그 글의 핵심 도메인 모델로 태그 연관, Action Text 본문, 커버 이미지 variant, 발행/검색/아카이브 scope를 정의한다. slug 생성, 단어 수 동기화, Base64 코드블록 디코딩 렌더링까지 담당한다.",
+      "tags": [
+        "data-model",
+        "active-record",
+        "domain-core",
+        "content-pipeline",
+        "scopes",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rails 콜백(before_validation/before_save)과 scope 람다로 조회 로직을 모델에 응집시키는 전형적인 Active Record 패턴이다."
+    },
+    {
+      "id": "class:app/models/post.rb:Post",
+      "type": "class",
+      "name": "Post",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        1,
+        192
+      ],
+      "summary": "published/by_category/search/by_tag 등의 scope와 slug 주소 지정, 이전·다음 글, 추천 글, 렌더링 파이프라인을 제공하는 Active Record 모델이다.",
+      "tags": [
+        "data-model",
+        "active-record",
+        "domain-core",
+        "scopes"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:app/models/post.rb:to_param",
+      "type": "function",
+      "name": "to_param",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        46,
+        48
+      ],
+      "summary": "URL 파라미터로 slug가 있으면 slug를, 없으면 id를 반환한다. 한국어 제목처럼 slug가 비는 경우 id로 폴백하는 주소 체계의 기준점이다.",
+      "tags": [
+        "routing",
+        "slug",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:find_by_slug_or_id",
+      "type": "function",
+      "name": "self.find_by_slug_or_id",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        53,
+        60
+      ],
+      "summary": "숫자면 id, 아니면 slug로 레코드를 찾되 현재 scope(all)를 유지해 미발행 글 노출을 막는다.",
+      "tags": [
+        "lookup",
+        "slug",
+        "security",
+        "scoping"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:recommended_posts",
+      "type": "function",
+      "name": "recommended_posts",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        86,
+        97
+      ],
+      "summary": "현재 글과 태그를 공유하는 발행된 글을 조인으로 조회해 자신을 제외한 추천 목록을 반환한다.",
+      "tags": [
+        "query",
+        "recommendation",
+        "tags",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/models/post.rb:tag_list=",
+      "type": "function",
+      "name": "tag_list=",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        104,
+        116
+      ],
+      "summary": "쉼표 구분 문자열을 파싱해 Tag를 찾거나 생성하고 연관을 갱신한다. 태그 집합이 실제로 달라졌을 때만 touch해 불필요한 캐시 무효화를 피한다.",
+      "tags": [
+        "tags",
+        "setter",
+        "caching",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:app/models/post.rb:read_time",
+      "type": "function",
+      "name": "read_time",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        120,
+        124
+      ],
+      "summary": "저장된 word_count 컬럼을 분당 단어 수로 나눠 최소 1분의 예상 읽기 시간을 계산한다. 본문 파싱을 하지 않아 조회 비용이 없다.",
+      "tags": [
+        "performance",
+        "presentation",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:rendered_content",
+      "type": "function",
+      "name": "rendered_content",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        129,
+        164
+      ],
+      "summary": "Action Text 본문의 BASE64 코드블록을 디코딩하고 레거시 ⟦ERB_*⟧ 플레이스홀더를 복원해 html_safe HTML을 반환한다. 디코딩에 실패하면 경고 로그를 남기고 원문을 그대로 둔다.",
+      "tags": [
+        "content-pipeline",
+        "serialization",
+        "base64",
+        "rendering"
+      ],
+      "complexity": "complex",
+      "languageNotes": "html_safe를 반환하므로 뷰는 반드시 content 대신 rendered_content를 써야 하고, 입력은 저장 시점에 컨트롤러가 인코딩한 값이라는 전제가 깔려 있다."
+    },
+    {
+      "id": "function:app/models/post.rb:sync_word_count",
+      "type": "function",
+      "name": "sync_word_count",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        178,
+        180
+      ],
+      "summary": "before_save 콜백으로 본문 평문의 단어 수를 세어 word_count 컬럼에 저장한다. read_time이 매 요청마다 본문을 파싱하지 않도록 하는 비정규화 캐시다.",
+      "tags": [
+        "callback",
+        "denormalization",
+        "performance",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:generate_slug",
+      "type": "function",
+      "name": "generate_slug",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        183,
+        191
+      ],
+      "summary": "before_validation 콜백으로 제목을 parameterize해 slug를 만든다. 한국어 제목은 빈 문자열이 되어 nil로 남고 id 기반 주소로 폴백된다.",
+      "tags": [
+        "callback",
+        "slug",
+        "i18n",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:app/views/layouts/application.html.erb",
+      "type": "file",
+      "name": "application.html.erb",
+      "filePath": "app/views/layouts/application.html.erb",
+      "summary": "전체 페이지의 최상위 레이아웃으로 메타/OG 태그, importmap 스크립트, 헤더·푸터·검색 UI를 구성한다. Prism·Mermaid·MathJax는 content_library? 판정에 따라 필요한 페이지에서만 조건부 로드하고, 제거된 style.min.css 링크는 더 이상 포함하지 않는다.",
+      "tags": [
+        "layout",
+        "entry-point",
+        "markup",
+        "performance",
+        "asset-loading"
+      ],
+      "complexity": "complex",
+      "languageNotes": "ERB 레이아웃에서 yield와 content_for로 페이지별 head 조각을 주입하고, 뷰가 선언한 라이브러리 요구를 헬퍼로 읽어 스크립트 태그를 게이팅한다."
+    },
+    {
+      "id": "file:app/views/posts/_form.html.erb",
+      "type": "file",
+      "name": "_form.html.erb",
+      "filePath": "app/views/posts/_form.html.erb",
+      "summary": "게시글 생성/수정에 공통으로 쓰이는 form_with 파셜로 제목·slug·요약·게시일·커버 이미지·작성자·태그·카테고리 필드와 TinyMCE가 붙는 content 텍스트영역을 렌더링한다. 상단에서 require_content_libraries :prism 을 선언해 TinyMCE codesample 플러그인이 참조하는 전역 Prism 을 미리 확보한다.",
+      "tags": [
+        "view",
+        "partial",
+        "form",
+        "admin",
+        "tinymce"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "ERB 파셜에서 `post.errors[:필드].any?` 결과로 인라인 style 을 분기해 필드별 에러 표시를 처리한다. 편집기 초기화에 필요한 프런트엔드 라이브러리를 뷰가 직접 선언하는 require_content_libraries 패턴을 사용한다."
+    },
+    {
+      "id": "file:app/views/posts/_post_meta.html.erb",
+      "type": "file",
+      "name": "_post_meta.html.erb",
+      "filePath": "app/views/posts/_post_meta.html.erb",
+      "summary": "게시글의 카테고리·게시일·읽기 시간 메타 정보를 그리는 최소 단위 파셜이다. local_assigns.fetch(:show_category, false) 로 넘어온 show_category 로컬을 실제로 사용해 상세 페이지에서만 카테고리 링크를 노출하고, 목록 카드에서는 카드 자체가 카테고리를 보여주므로 생략한다.",
+      "tags": [
+        "view",
+        "partial",
+        "metadata",
+        "component"
+      ],
+      "complexity": "simple",
+      "languageNotes": "선택적 로컬 변수를 안전하게 읽기 위해 `local_assigns.fetch(:show_category, false)` 를 쓴다. 로컬을 전달하지 않은 호출부에서도 NameError 없이 기본값으로 동작한다."
+    },
+    {
+      "id": "file:app/views/posts/index.html.erb",
+      "type": "file",
+      "name": "index.html.erb",
+      "filePath": "app/views/posts/index.html.erb",
+      "summary": "블로그 메인 페이지 템플릿으로 featured 게시글 1건, secondary 3건, 나머지 more_posts 목록과 Kaminari 페이지네이션을 계층적으로 렌더링한다. `@posts.to_a` 로 relation 을 한 번만 적재한 뒤 first/drop 을 적용해 중복 쿼리와 불필요한 프리로드를 제거했고, 모든 게시글 링크에는 `data: { turbo: false }` 를 붙여 전체 페이지 이동을 강제한다.",
+      "tags": [
+        "view",
+        "entry-point",
+        "listing",
+        "pagination",
+        "performance"
+      ],
+      "complexity": "complex",
+      "languageNotes": "ActiveRecord relation 에 `first` 를 먼저 호출하면 별도 LIMIT 1 쿼리와 프리로드가 추가로 발생하고 이어지는 `drop` 이 relation 을 다시 통째로 적재한다. `to_a` 로 한 번만 구체화한 뒤 배열 연산을 하는 것이 N+1/중복 쿼리 회피의 핵심이며, 페이지네이션 헬퍼에는 relation 인 `@posts` 를 그대로 넘긴다."
+    },
+    {
+      "id": "file:app/views/posts/show.html.erb",
+      "type": "file",
+      "name": "show.html.erb",
+      "filePath": "app/views/posts/show.html.erb",
+      "summary": "게시글 상세 페이지 템플릿으로 헤더(메타·저자·LCP 커버 이미지), 본문, 태그, 사이드바, 공유 메타바, 이전/다음 글과 추천 글 파셜을 조립한다. 비용이 큰 `rendered_content` 디코딩을 `post_body` 지역 변수에 한 번만 담아 `content_libraries_for` 판별과 실제 렌더링에 함께 재사용하고, 필요한 프런트엔드 라이브러리를 `require_content_libraries` 로 선언한다.",
+      "tags": [
+        "view",
+        "detail-page",
+        "seo",
+        "performance",
+        "composition"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Base64 코드블록 파이프라인 때문에 표시용 본문은 반드시 `content` 가 아닌 `rendered_content` 를 써야 한다. 상세 페이지 커버 이미지는 LCP 요소이므로 `lazy: false` + `fetchpriority: true` 를 주는 유일한 이미지이며, 링크 복사 알림 span 은 `data-share-notification` 훅으로 JS 와 연결된다."
+    },
+    {
+      "id": "file:config/application.rb",
+      "type": "file",
+      "name": "application.rb",
+      "filePath": "config/application.rb",
+      "summary": "Rails 애플리케이션의 전역 설정 진입점으로, load_defaults 8.0 과 lib 오토로드 범위를 정의하고 Active Storage 의 WebP 허용 타입·vips variant 프로세서·rails_storage_proxy 라우팅을 설정한다. 또한 exceptions_app 을 라우터로 지정해 동적 오류 페이지(ErrorsController)를 사용하게 만든다.",
+      "tags": [
+        "entry-point",
+        "configuration",
+        "rails-application",
+        "active-storage",
+        "bootstrap"
+      ],
+      "complexity": "simple",
+      "languageNotes": "resolve_model_to_route = :rails_storage_proxy 는 기본값 redirect 가 만드는 302 왕복과 private Cache-Control 을 없애, 앞단 Cloudflare 가 이미지 응답을 캐시할 수 있게 하는 Rails 관용 설정이다."
+    },
+    {
+      "id": "class:config/application.rb:BlogWithRails",
+      "type": "class",
+      "name": "BlogWithRails",
+      "filePath": "config/application.rb",
+      "lineRange": [
+        9,
+        44
+      ],
+      "summary": "Rails::Application 을 상속한 Application 클래스를 감싸는 최상위 애플리케이션 모듈로, 프레임워크 기본값·오토로드 경로·Active Storage 이미지 파이프라인·예외 처리 앱을 한곳에서 선언한다.",
+      "tags": [
+        "rails-application",
+        "configuration",
+        "namespace",
+        "bootstrap"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:config/brakeman.ignore",
+      "type": "file",
+      "name": "brakeman.ignore",
+      "filePath": "config/brakeman.ignore",
+      "summary": "Brakeman 정적 보안 분석의 경고 억제 목록 파일이다. 유일한 억제 항목이었던 ThumbnailsController 관련 경고가 해당 컨트롤러 삭제와 함께 제거되어 현재 ignored_warnings 는 비어 있다.",
+      "tags": [
+        "security",
+        "configuration",
+        "static-analysis",
+        "suppression"
+      ],
+      "complexity": "simple",
+      "languageNotes": "억제 목록이 비었다는 것은 현재 코드베이스가 Brakeman 경고 0건으로 통과한다는 뜻이므로, 새 경고를 여기에 추가하기 전에 실제 취약점인지 먼저 검토해야 한다."
+    },
+    {
+      "id": "file:config/environments/test.rb",
+      "type": "file",
+      "name": "test.rb",
+      "filePath": "config/environments/test.rb",
+      "summary": "테스트 환경 전용 Rails 설정으로, 리로딩 비활성화·CI 에서만 eager load·CSRF 보호 해제·Active Storage 및 Action Mailer 의 :test 어댑터를 지정한다. 캐시 스토어는 :null_store 에서 :memory_store 로 바뀌어 로그인 스로틀링(rate_limit) 카운터가 실제로 누적되도록 한다.",
+      "tags": [
+        "configuration",
+        "test",
+        "environment",
+        "caching"
+      ],
+      "complexity": "simple",
+      "languageNotes": ":null_store 는 write 를 버리기 때문에 캐시 카운터에 의존하는 rate_limit 계열 기능이 테스트에서 영영 발동하지 않는다. :memory_store 로 바꾼 대신 테스트 간 오염을 막으려 test/test_helper.rb 가 매 테스트마다 캐시를 비운다."
+    },
+    {
+      "id": "file:config/importmap.rb",
+      "type": "file",
+      "name": "importmap.rb",
+      "filePath": "config/importmap.rb",
+      "summary": "importmap-rails 의 ESM 핀 선언 파일로, application 엔트리·Hotwired Turbo/Stimulus 런타임·app/javascript/controllers 하위 Stimulus 컨트롤러 일괄 핀·init 모듈을 매핑한다. 에디터로 TinyMCE 를 쓰므로 Trix/Action Text JS 핀은 제거된 상태다.",
+      "tags": [
+        "configuration",
+        "importmap",
+        "frontend",
+        "javascript",
+        "build-system"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Trix/Action Text JS 핀을 빼도 서버 측 has_rich_text 는 그대로 동작한다. 프런트 에디터만 TinyMCE 로 대체되고 Action Text 의 저장·렌더 경로는 유지되기 때문이다."
+    },
+    {
+      "id": "file:config/routes.rb",
+      "type": "file",
+      "name": "routes.rb",
+      "filePath": "config/routes.rb",
+      "summary": "애플리케이션 전체 URL 라우팅 테이블. 글 목록/상세(slug 또는 id), 카테고리·태그·연도 아카이브·검색, 세션 기반 관리자 로그인, TinyMCE 이미지 업로드, 그리고 exceptions_app 으로 연결되는 동적 에러 페이지(/404, /422, /500)를 정의한다. 인증 없이 width 파라미터로 캐시를 축출시킬 수 있었고 어떤 뷰도 참조하지 않던 `thumbnails/:filename` 라우트는 제거되었다.",
+      "tags": [
+        "routing",
+        "entry-point",
+        "configuration",
+        "rails",
+        "security"
+      ],
+      "complexity": "simple",
+      "languageNotes": "Rails 라우팅 DSL. `resources :posts` 의 collection 블록으로 컬렉션 레벨 커스텀 경로를 만들고, constraints 로 :page(\\d+)·:year(\\d{4}) 형식을 강제해 잘못된 요청이 컨트롤러까지 도달하지 않게 막는다."
+    },
+    {
+      "id": "file:db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "type": "file",
+      "name": "20260801060000_add_word_count_to_posts.rb",
+      "filePath": "db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "summary": "posts 테이블에 word_count 정수 컬럼을 추가하고 기존 글의 본문을 한 번만 읽어 백필하는 마이그레이션. 목록 카드마다 Action Text 본문을 파싱해 read_time 을 계산하던 비용을 제거하기 위한 것이다.",
+      "tags": [
+        "migration",
+        "database",
+        "performance",
+        "rails",
+        "backfill"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:db/migrate/20260801060000_add_word_count_to_posts.rb:AddWordCountToPosts",
+      "type": "class",
+      "name": "AddWordCountToPosts",
+      "filePath": "db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "lineRange": [
+        1,
+        17
+      ],
+      "summary": "up 에서 posts.word_count 컬럼을 추가한 뒤 `Post.reset_column_information` 으로 컬럼 캐시를 갱신하고, rich_text_content 를 eager load 한 채 find_each 로 순회하며 본문 단어 수를 update_column 으로 백필한다. down 은 컬럼을 제거한다.",
+      "tags": [
+        "migration",
+        "backfill",
+        "data-model",
+        "performance"
+      ],
+      "complexity": "simple",
+      "languageNotes": "change 대신 up/down 을 쓴 이유는 백필이 되돌릴 수 없는 데이터 조작이기 때문이다. `includes(:rich_text_content)` 로 Action Text N+1 을 피하고, `update_column` 은 검증·콜백·updated_at 갱신을 건너뛴다."
+    },
+    {
+      "id": "file:db/schema.rb",
+      "type": "file",
+      "name": "schema.rb",
+      "filePath": "db/schema.rb",
+      "summary": "마이그레이션으로부터 자동 생성된 현재 DB 스키마 스냅샷(version 2026_08_01_060000). Action Text·Active Storage 테이블, admins, posts(신규 word_count 컬럼 포함), tags 와 posts_tags 조인 테이블 및 인덱스·외래키를 정의한다.",
+      "tags": [
+        "database",
+        "schema-definition",
+        "data-model",
+        "rails",
+        "generated"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "posts 는 slug 유니크 인덱스와 published_at·category 인덱스를 갖는데, 각각 slug/id 겸용 조회와 공개 범위(published_at <= now) 필터링·카테고리 목록 조회를 뒷받침한다. posts_tags 는 `id: false` 인 순수 조인 테이블이다."
+    },
+    {
+      "id": "file:script/subset_fonts.py",
+      "type": "file",
+      "name": "subset_fonts.py",
+      "filePath": "script/subset_fonts.py",
+      "summary": "app/assets/fonts 의 Lato woff2 를 라틴 범위로 서브셋해 파일당 200KB 안팎이던 용량을 40KB대로 줄이는 빌드 유틸리티. 사이트에 실제로 등장하면서 원본이 지원하던 코드포인트가 서브셋 후 빠지지 않는지 검사하며, --check 로 파일을 쓰지 않고 검증만 할 수도 있다.",
+      "tags": [
+        "build-system",
+        "performance",
+        "font-subsetting",
+        "script",
+        "utility"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "fontTools 의 subset 모듈을 사용한다. 이미 서브셋된 폰트를 다시 돌려도 안전 조건이 유지되므로 반복 실행이 가능(idempotent)하며, Windows cp949 콘솔에서 한글이 깨지지 않도록 `sys.stdout.reconfigure(encoding=\"utf-8\")` 를 호출한다."
+    },
+    {
+      "id": "function:script/subset_fonts.py:site_codepoints",
+      "type": "function",
+      "name": "site_codepoints",
+      "filePath": "script/subset_fonts.py",
+      "lineRange": [
+        54,
+        84
+      ],
+      "summary": "사이트에 렌더링될 수 있는 문자를 넓게 수집해 코드포인트 집합으로 돌려준다. 뷰·CSS·JS·로케일 파일을 glob 으로 훑고, storage 의 SQLite DB 가 있으면 posts 제목·요약과 Action Text 본문(태그 제거 + HTML 엔티티 언이스케이프)·태그 이름까지 읽어들인다.",
+      "tags": [
+        "utility",
+        "analysis",
+        "font-subsetting",
+        "sqlite"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:script/subset_fonts.py:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "script/subset_fonts.py",
+      "lineRange": [
+        87,
+        147
+      ],
+      "summary": "각 lato-*.woff2 에 대해 원본 cmap 과 사이트 사용 코드포인트의 교집합을 안전 기준으로 삼아 fontTools subset 을 실행하고, 결과 폰트가 그 기준을 모두 포함하는지 재검증한 뒤에만 원본을 교체한다. 검증에 실패하면 임시 파일을 지우고 누락 문자를 보고하며 비정상 종료한다.",
+      "tags": [
+        "entry-point",
+        "build-system",
+        "validation",
+        "font-subsetting"
+      ],
+      "complexity": "complex",
+      "languageNotes": "\"쓰기 전에 검증\" 패턴 — 새 파일을 임시 경로에 만들고 안전 조건을 확인한 뒤 `os.replace` 로 원자적으로 교체하므로, 실패해도 원본 폰트가 손상되지 않는다."
+    },
+    {
+      "id": "file:test/controllers/posts_controller_test.rb",
+      "type": "file",
+      "name": "posts_controller_test.rb",
+      "filePath": "test/controllers/posts_controller_test.rb",
+      "summary": "PostsController 의 CRUD 와 공개/비공개 스코프, HTTP 캐싱 동작을 검증하는 통합 테스트다. 특히 조건부 GET 이 실제로 304 Not Modified 를 돌려주는지, ETag 가 내용이 같을 때 안정적으로 유지되고 글이 수정되면 바뀌는지를 요청 수준에서 확인한다.",
+      "tags": [
+        "test",
+        "integration-test",
+        "http-caching",
+        "authorization",
+        "controller"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "ActionDispatch::IntegrationTest 로 If-None-Match 헤더를 직접 보내 304 를 확인한다. relation 을 그대로 ETag 로 넘기면 published 스코프의 Time.current 가 to_sql 에 박혀 매 요청 ETag 가 달라진다는 회귀를 이 테스트가 막는다."
+    },
+    {
+      "id": "class:test/controllers/posts_controller_test.rb:PostsControllerTest",
+      "type": "class",
+      "name": "PostsControllerTest",
+      "filePath": "test/controllers/posts_controller_test.rb",
+      "lineRange": [
+        3,
+        162
+      ],
+      "summary": "관리자로 로그인한 상태를 setup 에서 만들고, 필요할 때 logout 해 공개 방문자 시나리오로 전환하며 게시글 조회/생성/수정/삭제와 캐시 헤더, 예약 게시글 노출 여부를 검증하는 테스트 클래스다.",
+      "tags": [
+        "test",
+        "integration-test",
+        "controller",
+        "caching",
+        "scheduled-posts"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:test/controllers/sessions_controller_test.rb",
+      "type": "file",
+      "name": "sessions_controller_test.rb",
+      "filePath": "test/controllers/sessions_controller_test.rb",
+      "summary": "관리자 로그인/로그아웃과 브루트포스 스로틀링을 검증하는 통합 테스트다. 쿠키를 통째로 버려도(reset!) 스로틀이 유지되는지, 성공한 로그인은 한도에 포함되지 않는지, 성공이 이전 실패 카운터를 지우는지를 회귀 테스트로 고정한다.",
+      "tags": [
+        "test",
+        "integration-test",
+        "authentication",
+        "rate-limiting",
+        "security"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "예전 잠금은 시도 횟수를 세션(쿠키)에 저장해 쿠키를 버리면 무한 시도가 가능했다. `reset!` 로 클라이언트를 새로 만드는 테스트가 그 회귀를 직접 겨냥한다."
+    },
+    {
+      "id": "class:test/controllers/sessions_controller_test.rb:SessionsControllerTest",
+      "type": "class",
+      "name": "SessionsControllerTest",
+      "filePath": "test/controllers/sessions_controller_test.rb",
+      "lineRange": [
+        3,
+        114
+      ],
+      "summary": "로그인 페이지 렌더링, 자격증명 검증, 세션 키 설정, MAX_LOGIN_ATTEMPTS 기반 429 잠금, 남은 시도 횟수 안내 flash 를 아우르는 세션 컨트롤러 테스트 클래스다.",
+      "tags": [
+        "test",
+        "authentication",
+        "rate-limiting",
+        "session",
+        "security"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:test/controllers/uploads_controller_test.rb",
+      "type": "file",
+      "name": "uploads_controller_test.rb",
+      "filePath": "test/controllers/uploads_controller_test.rb",
+      "summary": "이전까지 테스트가 전혀 없던 이미지 업로드 엔드포인트를 처음으로 덮는 신규 통합 테스트다. 비로그인 차단, 파일 타입/누락 검증, Active Storage 저장과 분석된 크기 반환, 그리고 응답 URL 이 CDN 캐시 가능한 proxy 경로로 나가는지(redirect 서명 URL 이 아닌지)를 확인한다.",
+      "tags": [
+        "test",
+        "integration-test",
+        "file-upload",
+        "active-storage",
+        "cdn-caching"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "redirect 라우트는 5분 만료 서명 URL 로 302 를 보내고 Cache-Control 에 private 이 붙어 Cloudflare 가 캐시하지 못한다. 그래서 본문 이미지도 `/rails/active_storage/blobs/proxy/` 경로로 나가야 한다는 계약을 테스트로 못박았다."
+    },
+    {
+      "id": "class:test/controllers/uploads_controller_test.rb:UploadsControllerTest",
+      "type": "class",
+      "name": "UploadsControllerTest",
+      "filePath": "test/controllers/uploads_controller_test.rb",
+      "lineRange": [
+        3,
+        76
+      ],
+      "summary": "fixture PNG 를 실제로 POST 해 인증 거부, 잘못된 MIME 타입 거부(422), Blob 개수 증가, srcset 이 원본 폭 이하의 프리셋 variant proxy URL 로만 구성되는지를 검증하는 업로드 테스트 클래스다.",
+      "tags": [
+        "test",
+        "file-upload",
+        "active-storage",
+        "validation",
+        "srcset"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:test/helpers/image_helper_test.rb",
+      "type": "file",
+      "name": "image_helper_test.rb",
+      "filePath": "test/helpers/image_helper_test.rb",
+      "summary": "ImageHelper 의 intrinsic_dimensions 계산을 단위 수준에서 검증하는 신규 테스트다. Struct 로 만든 가짜 blob/attachment 를 써서 Active Storage 없이도 축소 시 종횡비 보존, 확대 금지, height 상한 적용, 분석 전 blob 에서는 속성 생략을 확인한다.",
+      "tags": [
+        "test",
+        "helper-test",
+        "image-processing",
+        "aspect-ratio",
+        "unit-test"
+      ],
+      "complexity": "simple",
+      "languageNotes": "`Struct.new` 로 blob 을 흉내 내고 `send` 로 private helper 를 직접 호출해, DB·파일 IO 없이 순수 계산만 떼어 테스트한다."
+    },
+    {
+      "id": "class:test/helpers/image_helper_test.rb:ImageHelperTest",
+      "type": "class",
+      "name": "ImageHelperTest",
+      "filePath": "test/helpers/image_helper_test.rb",
+      "lineRange": [
+        3,
+        37
+      ],
+      "summary": "ActionView::TestCase 기반으로 width/height 속성 계산 규칙 다섯 가지를 검증한다. 브라우저가 width/height 로 aspect-ratio 를 잡기 때문에 값이 틀리면 이미지가 늘어난다는 점이 이 테스트의 근거다.",
+      "tags": [
+        "test",
+        "helper-test",
+        "image-processing",
+        "unit-test",
+        "layout-stability"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:test/models/post_test.rb",
+      "type": "file",
+      "name": "post_test.rb",
+      "filePath": "test/models/post_test.rb",
+      "summary": "Post 모델의 유효성 검사, slug 생성(영문 parameterize / 한글은 nil 후 id 폴백), 스코프, 태그 갱신, Active Storage variant 생성까지 폭넓게 검증하는 모델 테스트다. 저장 시 word_count 가 본문과 동기화되는지와 Base64 디코딩 실패 시 원문을 보존하는지가 핵심 회귀 지점이다.",
+      "tags": [
+        "test",
+        "model-test",
+        "validation",
+        "slug",
+        "content-pipeline"
+      ],
+      "complexity": "complex",
+      "languageNotes": "디코딩 정규식이 인코딩 정규식보다 넓어, 인코딩되지 않은 코드 블록이 렌더 시점에 매칭되면 예전에는 strict_decode64 가 ArgumentError 를 던져 해당 글이 500 이 됐다. `assert_nothing_raised` 로 원문 보존을 고정한다."
+    },
+    {
+      "id": "class:test/models/post_test.rb:PostTest",
+      "type": "class",
+      "name": "PostTest",
+      "filePath": "test/models/post_test.rb",
+      "lineRange": [
+        3,
+        279
+      ],
+      "summary": "Post 의 검증·slug·to_param·find_by_slug_or_id 스코프 보존·search/by_year/by_tag 스코프·태그 재할당 시 updated_at 유지·rendered_content 디코딩·read_time 과 word_count·published 스코프·cover_image variant 생성을 모두 다루는 대형 모델 테스트 클래스다.",
+      "tags": [
+        "test",
+        "model-test",
+        "scopes",
+        "caching",
+        "active-storage"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:test/test_helper.rb",
+      "type": "file",
+      "name": "test_helper.rb",
+      "filePath": "test/test_helper.rb",
+      "summary": "모든 테스트가 require 하는 부트스트랩 파일이다. SimpleCov(브랜치 커버리지, 병렬 워커별 command_name) 설정, Rails 환경 로드, 병렬 실행과 fixtures :all 을 세팅하고, 매 테스트 시작마다 Rails.cache.clear 를 실행한다.",
+      "tags": [
+        "test",
+        "test-setup",
+        "coverage",
+        "entry-point",
+        "cache"
+      ],
+      "complexity": "simple",
+      "languageNotes": "테스트 환경이 rate_limit 검증을 위해 :memory_store 를 쓰면서 캐시가 테스트 간에 살아남는다. 로그인 스로틀 카운터는 IP(127.0.0.1) 단위라 비우지 않으면 setup 에서 로그인하는 테스트들이 서로를 한도 너머로 밀어내 429 를 받는다 — `setup { Rails.cache.clear }` 가 그 격리를 담당한다."
+    },
+    {
+      "id": "class:test/test_helper.rb:ActiveSupport::TestCase",
+      "type": "class",
+      "name": "ActiveSupport::TestCase",
+      "filePath": "test/test_helper.rb",
+      "lineRange": [
+        23,
+        58
+      ],
+      "summary": "모든 테스트의 공통 베이스 클래스를 재개방(reopen)해 병렬 실행, SimpleCov 워커별 결과 병합, fixtures 로드, 테스트마다 캐시 비우기, sign_in_as_admin 헬퍼를 주입한다.",
+      "tags": [
+        "test",
+        "test-setup",
+        "parallel-testing",
+        "fixtures",
+        "shared-helper"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:test/test_helper.rb:sign_in_as_admin",
+      "type": "function",
+      "name": "sign_in_as_admin",
+      "filePath": "test/test_helper.rb",
+      "lineRange": [
+        53,
+        56
+      ],
+      "summary": "fixture 관리자(admins(:one))로 login_url 에 POST 해 관리자 세션을 만드는 공용 헬퍼로, 업로드 및 관리자 전용 posts 액션 테스트에서 사용한다.",
+      "tags": [
+        "test",
+        "shared-helper",
+        "authentication",
+        "fixtures"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:set_no_cache_headers",
+      "type": "function",
+      "name": "set_no_cache_headers",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        134,
+        138
+      ],
+      "summary": "관리자 응답에 no-store/no-cache/must-revalidate 헤더를 심어 미발행 글이 브라우저나 중간 캐시에 남지 않게 한다. 공개 응답의 fresh_when/stale? ETag 경로와 짝을 이루는 반대편 분기다.",
+      "tags": [
+        "caching",
+        "security",
+        "http-headers",
+        "admin"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:self.find_by_slug_or_id!",
+      "type": "function",
+      "name": "self.find_by_slug_or_id!",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        62,
+        64
+      ],
+      "summary": "find_by_slug_or_id 가 nil 을 돌려주면 RecordNotFound 를 던지는 bang 변형. all 을 경유하므로 호출 시점의 스코프가 유지돼 미공개 글이 새지 않는다.",
+      "tags": [
+        "scope-safe",
+        "lookup",
+        "raises"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:self.yearly_archive_counts",
+      "type": "function",
+      "name": "self.yearly_archive_counts",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        67,
+        69
+      ],
+      "summary": "아카이브 사이드바용 연도별 게시글 수. published_at 을 전부 pluck 해 Ruby 에서 그룹핑하므로 글이 늘수록 선형으로 비용이 커진다.",
+      "tags": [
+        "archive",
+        "aggregate",
+        "performance-risk"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:previous_post",
+      "type": "function",
+      "name": "previous_post",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        76,
+        78
+      ],
+      "summary": "published_at 기준 이전 공개 글. 카드가 커버 이미지를 그리므로 with_attached_cover_image 로 첨부를 함께 적재해 카드당 추가 조회를 없앤다.",
+      "tags": [
+        "navigation",
+        "eager-loading",
+        "published-only"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:next_post",
+      "type": "function",
+      "name": "next_post",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        81,
+        83
+      ],
+      "summary": "published_at 기준 다음 공개 글. previous_post 와 같은 이유로 커버 이미지 첨부를 함께 적재한다.",
+      "tags": [
+        "navigation",
+        "eager-loading",
+        "published-only"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:tag_list",
+      "type": "function",
+      "name": "tag_list",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        100,
+        102
+      ],
+      "summary": "태그 이름을 쉼표로 이어 폼에 채워 넣는 getter. tag_list= 와 짝을 이룬다.",
+      "tags": [
+        "form",
+        "tags",
+        "getter"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/models/post.rb:cover_image_caption",
+      "type": "function",
+      "name": "cover_image_caption",
+      "filePath": "app/models/post.rb",
+      "lineRange": [
+        167,
+        171
+      ],
+      "summary": "커버 이미지 blob 메타데이터에서 캡션을 꺼낸다. 첨부가 없으면 nil 을 돌려준다.",
+      "tags": [
+        "active-storage",
+        "metadata"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        78,
+        80
+      ],
+      "summary": "관리자 전용 새 글 작성 폼. authenticate_admin! 로 보호되며 빈 Post 를 뷰에 넘긴다.",
+      "tags": [
+        "admin-only",
+        "form",
+        "crud"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:app/controllers/posts_controller.rb:edit",
+      "type": "function",
+      "name": "edit",
+      "filePath": "app/controllers/posts_controller.rb",
+      "lineRange": [
+        83,
+        84
+      ],
+      "summary": "관리자 전용 수정 폼. set_post 가 post_scope 를 경유해 조회하므로 미공개 글도 관리자에게만 열린다.",
+      "tags": [
+        "admin-only",
+        "form",
+        "crud"
+      ],
+      "complexity": "simple"
+    }
+  ],
+  "edges": [
+    {
+      "source": "service:Dockerfile",
+      "target": "service:Dockerfile:base",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "service:Dockerfile:build",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "file:bin/docker-entrypoint",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "file:bin/thrust",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "file:bin/rails",
+      "type": "deploys",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "file:Gemfile",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "service:Dockerfile",
+      "target": "service:.dockerignore",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.rubocop.yml",
+      "target": "file:bin/rubocop",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:app/controllers/errors_controller.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:app/models/admin.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:app/javascript/init.js",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:config/initializers/action_text.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:config/initializers/content_security_policy.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:config/initializers/security_headers.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:config/initializers/cloudflare.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:db/seeds.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:bin/check-code",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "file:bin/ci",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:CLAUDE.md",
+      "target": "config:config/deploy.yml",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:app/models/tag.rb",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:bin/dev",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "file:bin/check-code",
+      "type": "documents",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "document:README.md",
+      "target": "service:Dockerfile",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:config/bundler-audit.yml",
+      "target": "file:Gemfile",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/cable.yml",
+      "target": "config:config/database.yml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/cable.yml",
+      "target": "file:db/cable_schema.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:config/cache.yml",
+      "target": "config:config/database.yml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/cache.yml",
+      "target": "file:db/cache_schema.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:config/deploy.yml",
+      "target": "service:Dockerfile",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/deploy.yml",
+      "target": "file:.kamal/secrets",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/queue.yml",
+      "target": "config:config/database.yml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/queue.yml",
+      "target": "file:db/queue_schema.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "config:config/recurring.yml",
+      "target": "config:config/queue.yml",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:config/storage.yml",
+      "target": "file:config/environments/production.rb",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:public/400.html",
+      "target": "file:public/404.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:public/406-unsupported-browser.html",
+      "target": "file:public/404.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:public/422.html",
+      "target": "file:public/404.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:public/500.html",
+      "target": "file:public/404.html",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "class:app/controllers/errors_controller.rb:ErrorsController",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "class:app/controllers/errors_controller.rb:ErrorsController",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "file:app/models/tag.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "config:.github/dependabot.yml",
+      "target": "file:Gemfile",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:Procfile.dev",
+      "target": "file:bin/rails",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:.kamal/secrets",
+      "target": "config:config/deploy.yml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:.kamal/hooks/pre-build.sample",
+      "target": "config:config/deploy.yml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:.kamal/hooks/pre-connect.sample",
+      "target": "config:config/deploy.yml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:.kamal/hooks/pre-deploy.sample",
+      "target": "config:config/deploy.yml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:.ruby-version",
+      "target": "file:Gemfile",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:.gitattributes",
+      "target": "file:bin/rails",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/javascript/controllers/search_controller.js",
+      "target": "class:app/javascript/controllers/search_controller.js:SearchController",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/controllers/search_controller.js",
+      "target": "function:app/javascript/controllers/search_controller.js:fadeInModal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/controllers/search_controller.js",
+      "target": "function:app/javascript/controllers/search_controller.js:fadeOutModal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/init.js",
+      "target": "function:app/javascript/init.js:decodeBase64CodeBlock",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/init.js",
+      "target": "function:app/javascript/init.js:decodeLegacyErbPlaceholders",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/init.js",
+      "target": "function:app/javascript/init.js:initTinyMCE",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/init.js",
+      "target": "function:app/javascript/init.js:handleCopyLink",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/init.js",
+      "target": "function:app/javascript/init.js:initializePage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/admin.rb",
+      "target": "class:app/models/admin.rb:Admin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/application_record.rb",
+      "target": "class:app/models/application_record.rb:ApplicationRecord",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/tag.rb",
+      "target": "class:app/models/tag.rb:Tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/tag.rb",
+      "target": "function:app/models/tag.rb:popular_with_counts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/tag.rb",
+      "target": "function:app/models/tag.rb:find_or_create_by_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/javascript/controllers/search_controller.js",
+      "target": "class:app/javascript/controllers/search_controller.js:SearchController",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/models/admin.rb",
+      "target": "class:app/models/admin.rb:Admin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/models/application_record.rb",
+      "target": "class:app/models/application_record.rb:ApplicationRecord",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/models/tag.rb",
+      "target": "class:app/models/tag.rb:Tag",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:app/models/admin.rb:Admin",
+      "target": "class:app/models/application_record.rb:ApplicationRecord",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:app/models/tag.rb:Tag",
+      "target": "class:app/models/application_record.rb:ApplicationRecord",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "file:app/javascript/controllers/index.js",
+      "target": "file:app/javascript/controllers/application.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/javascript/controllers/index.js",
+      "target": "file:app/javascript/controllers/search_controller.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/_post_navigation.html.erb",
+      "target": "file:app/views/posts/_post_card.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/kaminari/_paginator.html.erb",
+      "target": "file:app/views/kaminari/_page.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/kaminari/_paginator.html.erb",
+      "target": "file:app/views/kaminari/_prev_page.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show_all.html.erb",
+      "target": "file:app/views/kaminari/_paginator.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/check-code",
+      "target": "file:bin/brakeman",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/ci",
+      "target": "file:config/boot.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/ci",
+      "target": "file:config/ci.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/docker-entrypoint",
+      "target": "file:bin/rails",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/jobs",
+      "target": "file:config/environment.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/rails",
+      "target": "file:config/boot.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/rake",
+      "target": "file:config/boot.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/setup",
+      "target": "file:bin/rails",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:bin/setup",
+      "target": "file:bin/dev",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config.ru",
+      "target": "file:config/environment.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/ci.rb",
+      "target": "file:bin/setup",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/ci.rb",
+      "target": "file:bin/rubocop",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/ci.rb",
+      "target": "file:bin/importmap",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/ci.rb",
+      "target": "file:bin/rails",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:db/migrate/20251122082531_create_posts.rb",
+      "target": "class:db/migrate/20251122082531_create_posts.rb:CreatePosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20251122082531_create_posts.rb",
+      "target": "class:db/migrate/20251122082531_create_posts.rb:CreatePosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+      "target": "class:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb:CreateActiveStorageTables",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+      "target": "class:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb:CreateActiveStorageTables",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+      "target": "class:db/migrate/20251122082560_create_action_text_tables.action_text.rb:CreateActionTextTables",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+      "target": "class:db/migrate/20251122082560_create_action_text_tables.action_text.rb:CreateActionTextTables",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20251125033932_add_tags_to_posts.rb",
+      "target": "class:db/migrate/20251125033932_add_tags_to_posts.rb:AddTagsToPosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20251125033932_add_tags_to_posts.rb",
+      "target": "class:db/migrate/20251125033932_add_tags_to_posts.rb:AddTagsToPosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+      "target": "class:db/migrate/20251130051704_add_slug_and_category_to_posts.rb:AddSlugAndCategoryToPosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+      "target": "class:db/migrate/20251130051704_add_slug_and_category_to_posts.rb:AddSlugAndCategoryToPosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "target": "class:db/migrate/20260319025507_create_tags_and_posts_tags.rb:CreateTagsAndPostsTags",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "target": "class:db/migrate/20260319025507_create_tags_and_posts_tags.rb:CreateTagsAndPostsTags",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "target": "class:db/migrate/20260319034444_remove_tags_string_from_posts.rb:RemoveTagsStringFromPosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "target": "class:db/migrate/20260319034444_remove_tags_string_from_posts.rb:RemoveTagsStringFromPosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20260324033356_create_admins.rb",
+      "target": "class:db/migrate/20260324033356_create_admins.rb:CreateAdmins",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20260324033356_create_admins.rb",
+      "target": "class:db/migrate/20260324033356_create_admins.rb:CreateAdmins",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+      "target": "class:db/migrate/20260731120000_add_published_at_index_to_posts.rb:AddPublishedAtIndexToPosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+      "target": "class:db/migrate/20260731120000_add_published_at_index_to_posts.rb:AddPublishedAtIndexToPosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/seeds.rb",
+      "target": "file:app/models/admin.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:lib/tasks/migrate_tags.rake",
+      "target": "file:app/models/tag.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:lib/tasks/import_from_sqlite.rake",
+      "target": "file:app/models/tag.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/initializers/content_security_policy.rb",
+      "target": "file:config/initializers/security_headers.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:lib/tasks/migrate_tags.rake",
+      "target": "file:db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:lib/tasks/migrate_tags.rake",
+      "target": "file:db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:config/puma.rb",
+      "target": "file:db/queue_schema.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:test/application_system_test_case.rb",
+      "target": "class:test/application_system_test_case.rb:ApplicationSystemTestCase",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/controllers/errors_controller_test.rb",
+      "target": "class:test/controllers/errors_controller_test.rb:ErrorsControllerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/models/tag_test.rb",
+      "target": "class:test/models/tag_test.rb:TagTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/application_system_test_case.rb",
+      "target": "class:test/application_system_test_case.rb:ApplicationSystemTestCase",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/controllers/errors_controller_test.rb",
+      "target": "class:test/controllers/errors_controller_test.rb:ErrorsControllerTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/models/tag_test.rb",
+      "target": "class:test/models/tag_test.rb:TagTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "config:test/fixtures/action_text/rich_texts.yml",
+      "target": "config:test/fixtures/posts.yml",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "file:app/views/errors/not_found.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6,
+      "description": "not_found 액션이 규약에 따라 404 템플릿을 :not_found 상태로 렌더링하며 @all_tags를 넘긴다."
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "file:app/views/errors/unprocessable.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6,
+      "description": "unprocessable 액션이 규약에 따라 422 템플릿을 :unprocessable_entity 상태로 렌더링한다."
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "file:app/views/errors/internal_server.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6,
+      "description": "internal_server 액션이 규약에 따라 500 템플릿을 :internal_server_error 상태로 렌더링한다."
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:test/test_helper.rb",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:test/models/post_test.rb",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:test/controllers/posts_controller_test.rb",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:test/controllers/sessions_controller_test.rb",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:test/controllers/uploads_controller_test.rb",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:test/helpers/image_helper_test.rb",
+      "type": "triggers",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/controllers/application_controller.rb",
+      "target": "class:app/controllers/application_controller.rb:ApplicationController",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/application_controller.rb",
+      "target": "class:app/controllers/application_controller.rb:ApplicationController",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "class:app/controllers/posts_controller.rb:PostsController",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "class:app/controllers/posts_controller.rb:PostsController",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "class:app/controllers/sessions_controller.rb:SessionsController",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "class:app/controllers/sessions_controller.rb:SessionsController",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/controllers/uploads_controller.rb",
+      "target": "class:app/controllers/uploads_controller.rb:UploadsController",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/uploads_controller.rb",
+      "target": "class:app/controllers/uploads_controller.rb:UploadsController",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "class:app/helpers/application_helper.rb:ApplicationHelper",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "class:app/helpers/application_helper.rb:ApplicationHelper",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/controllers/application_controller.rb",
+      "target": "function:app/controllers/application_controller.rb:set_no_transform_cache_control",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/application_controller.rb",
+      "target": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/application_controller.rb",
+      "target": "function:app/controllers/application_controller.rb:authenticate_admin!",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:index",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:search",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:archive",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:show",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:create",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:update",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:destroy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:set_post",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:post_scope",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:listing_scope",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:post_params",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:encode_code_blocks",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:create",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:destroy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:reject_when_throttled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:throttle_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:failed_attempts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:record_failed_attempt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "function:app/controllers/sessions_controller.rb:clear_failed_attempts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/uploads_controller.rb",
+      "target": "function:app/controllers/uploads_controller.rb:image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/controllers/uploads_controller.rb",
+      "target": "function:app/controllers/uploads_controller.rb:destroy_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "function:app/helpers/application_helper.rb:require_content_libraries",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "function:app/helpers/application_helper.rb:content_library?",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "function:app/helpers/application_helper.rb:content_libraries_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "function:app/helpers/application_helper.rb:math_delimiters?",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:app/controllers/posts_controller.rb:PostsController",
+      "target": "class:app/controllers/application_controller.rb:ApplicationController",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:app/controllers/sessions_controller.rb:SessionsController",
+      "target": "class:app/controllers/application_controller.rb:ApplicationController",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "class:app/controllers/uploads_controller.rb:UploadsController",
+      "target": "class:app/controllers/application_controller.rb:ApplicationController",
+      "type": "inherits",
+      "direction": "forward",
+      "weight": 0.9
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:index",
+      "target": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:show",
+      "target": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:post_scope",
+      "target": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:new",
+      "target": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:app/controllers/posts_controller.rb:PostsController",
+      "target": "function:app/controllers/application_controller.rb:authenticate_admin!",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:app/controllers/uploads_controller.rb:UploadsController",
+      "target": "function:app/controllers/application_controller.rb:authenticate_admin!",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/application_controller.rb:authenticate_admin!",
+      "target": "function:app/controllers/application_controller.rb:admin_signed_in?",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:index",
+      "target": "function:app/controllers/posts_controller.rb:listing_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:search",
+      "target": "function:app/controllers/posts_controller.rb:listing_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:archive",
+      "target": "function:app/controllers/posts_controller.rb:listing_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:tag",
+      "target": "function:app/controllers/posts_controller.rb:listing_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:show",
+      "target": "function:app/controllers/posts_controller.rb:post_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:set_post",
+      "target": "function:app/controllers/posts_controller.rb:post_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:listing_scope",
+      "target": "function:app/controllers/posts_controller.rb:post_scope",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:create",
+      "target": "function:app/controllers/posts_controller.rb:post_params",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:update",
+      "target": "function:app/controllers/posts_controller.rb:post_params",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:post_params",
+      "target": "function:app/controllers/posts_controller.rb:encode_code_blocks",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:create",
+      "target": "function:app/controllers/sessions_controller.rb:clear_failed_attempts",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:create",
+      "target": "function:app/controllers/sessions_controller.rb:record_failed_attempt",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:reject_when_throttled",
+      "target": "function:app/controllers/sessions_controller.rb:failed_attempts",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:failed_attempts",
+      "target": "function:app/controllers/sessions_controller.rb:throttle_key",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:record_failed_attempt",
+      "target": "function:app/controllers/sessions_controller.rb:throttle_key",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/sessions_controller.rb:clear_failed_attempts",
+      "target": "function:app/controllers/sessions_controller.rb:throttle_key",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/helpers/application_helper.rb:content_libraries_for",
+      "target": "function:app/helpers/application_helper.rb:math_delimiters?",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "file:app/models/post.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "file:app/models/admin.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/controllers/application_controller.rb",
+      "target": "file:app/models/admin.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/helpers/application_helper.rb",
+      "target": "file:app/views/layouts/application.html.erb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/assets/stylesheets/site.css",
+      "target": "file:app/views/layouts/application.html.erb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "class:app/helpers/image_helper.rb:ImageHelper",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "function:app/helpers/image_helper.rb:optimized_image_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "function:app/helpers/image_helper.rb:responsive_image_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "function:app/helpers/image_helper.rb:picture_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "function:app/helpers/image_helper.rb:intrinsic_dimensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "class:app/helpers/image_helper.rb:ImageHelper",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/helpers/image_helper.rb:optimized_image_tag",
+      "target": "function:app/helpers/image_helper.rb:intrinsic_dimensions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/helpers/image_helper.rb:responsive_image_tag",
+      "target": "function:app/helpers/image_helper.rb:intrinsic_dimensions",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:app/javascript/application.js",
+      "target": "file:app/javascript/init.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/javascript/application.js",
+      "target": "file:app/javascript/controllers/index.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "class:app/models/post.rb:Post",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:to_param",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:find_by_slug_or_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:recommended_posts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:tag_list=",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:read_time",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:rendered_content",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:sync_word_count",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "function:app/models/post.rb:generate_slug",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "class:app/models/post.rb:Post",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/models/post.rb:read_time",
+      "target": "function:app/models/post.rb:sync_word_count",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "file:app/models/tag.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/layouts/application.html.erb",
+      "target": "file:app/javascript/application.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/layouts/application.html.erb",
+      "target": "file:app/helpers/application_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/views/posts/_post_meta.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/views/posts/_sidebar.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/views/posts/_post_navigation.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/views/posts/_recommended_posts.html.erb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/helpers/application_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/helpers/image_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/models/post.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/javascript/init.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/index.html.erb",
+      "target": "file:app/helpers/image_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/index.html.erb",
+      "target": "file:app/models/post.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/index.html.erb",
+      "target": "file:app/controllers/posts_controller.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/views/posts/show.html.erb",
+      "target": "file:app/controllers/posts_controller.rb",
+      "type": "related",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/views/posts/_form.html.erb",
+      "target": "file:app/helpers/application_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/_form.html.erb",
+      "target": "file:app/javascript/init.js",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/_form.html.erb",
+      "target": "file:app/models/post.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/views/posts/_post_meta.html.erb",
+      "target": "file:app/models/post.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/application.rb",
+      "target": "file:config/boot.rb",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:config/application.rb",
+      "target": "class:config/application.rb:BlogWithRails",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:config/application.rb",
+      "target": "class:config/application.rb:BlogWithRails",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:config/importmap.rb",
+      "target": "file:app/javascript/application.js",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/importmap.rb",
+      "target": "file:app/javascript/init.js",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/environments/test.rb",
+      "target": "file:test/test_helper.rb",
+      "type": "configures",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/routes.rb",
+      "target": "file:app/controllers/posts_controller.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/routes.rb",
+      "target": "file:app/controllers/sessions_controller.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/routes.rb",
+      "target": "file:app/controllers/uploads_controller.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:config/routes.rb",
+      "target": "file:app/controllers/errors_controller.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "target": "class:db/migrate/20260801060000_add_word_count_to_posts.rb:AddWordCountToPosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "target": "class:db/migrate/20260801060000_add_word_count_to_posts.rb:AddWordCountToPosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "target": "file:app/models/post.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:db/schema.rb",
+      "target": "file:db/migrate/20260801060000_add_word_count_to_posts.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:script/subset_fonts.py",
+      "target": "function:script/subset_fonts.py:site_codepoints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:script/subset_fonts.py",
+      "target": "function:script/subset_fonts.py:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:script/subset_fonts.py",
+      "target": "function:script/subset_fonts.py:site_codepoints",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:script/subset_fonts.py",
+      "target": "function:script/subset_fonts.py:main",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/test_helper.rb",
+      "target": "file:config/environment.rb",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:test/controllers/posts_controller_test.rb",
+      "target": "class:test/controllers/posts_controller_test.rb:PostsControllerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/controllers/posts_controller_test.rb",
+      "target": "class:test/controllers/posts_controller_test.rb:PostsControllerTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/controllers/sessions_controller_test.rb",
+      "target": "class:test/controllers/sessions_controller_test.rb:SessionsControllerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/controllers/sessions_controller_test.rb",
+      "target": "class:test/controllers/sessions_controller_test.rb:SessionsControllerTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/controllers/uploads_controller_test.rb",
+      "target": "class:test/controllers/uploads_controller_test.rb:UploadsControllerTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/controllers/uploads_controller_test.rb",
+      "target": "class:test/controllers/uploads_controller_test.rb:UploadsControllerTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/helpers/image_helper_test.rb",
+      "target": "class:test/helpers/image_helper_test.rb:ImageHelperTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/helpers/image_helper_test.rb",
+      "target": "class:test/helpers/image_helper_test.rb:ImageHelperTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/models/post_test.rb",
+      "target": "class:test/models/post_test.rb:PostTest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/models/post_test.rb",
+      "target": "class:test/models/post_test.rb:PostTest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/test_helper.rb",
+      "target": "class:test/test_helper.rb:ActiveSupport::TestCase",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/test_helper.rb",
+      "target": "function:test/test_helper.rb:sign_in_as_admin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "class:test/test_helper.rb:ActiveSupport::TestCase",
+      "target": "function:test/test_helper.rb:sign_in_as_admin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "file:test/test_helper.rb",
+      "target": "function:test/test_helper.rb:sign_in_as_admin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:test/controllers/posts_controller_test.rb",
+      "target": "file:test/test_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:test/controllers/sessions_controller_test.rb",
+      "target": "file:test/test_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:test/controllers/uploads_controller_test.rb",
+      "target": "file:test/test_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:test/helpers/image_helper_test.rb",
+      "target": "file:test/test_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:test/models/post_test.rb",
+      "target": "file:test/test_helper.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:test/controllers/uploads_controller_test.rb",
+      "target": "function:test/test_helper.rb:sign_in_as_admin",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:config/environment.rb",
+      "target": "file:config/application.rb",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7,
+      "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "file:test/controllers/posts_controller_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "file:test/controllers/sessions_controller_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/controllers/uploads_controller.rb",
+      "target": "file:test/controllers/uploads_controller_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/helpers/image_helper.rb",
+      "target": "file:test/helpers/image_helper_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/models/post.rb",
+      "target": "file:test/models/post_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/controllers/errors_controller.rb",
+      "target": "file:test/controllers/errors_controller_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:app/models/tag.rb",
+      "target": "file:test/models/tag_test.rb",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "pipeline:.github/workflows/ci.yml",
+      "target": "file:config/brakeman.ignore",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "file:config/initializers/action_text.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/controllers/sessions_controller.rb",
+      "target": "file:config/initializers/cloudflare.rb",
+      "type": "depends_on",
+      "direction": "forward",
+      "weight": 0.6
+    },
+    {
+      "source": "file:app/controllers/posts_controller.rb",
+      "target": "function:app/controllers/posts_controller.rb:set_no_cache_headers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1.0
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:index",
+      "target": "function:app/controllers/posts_controller.rb:set_no_cache_headers",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:app/controllers/posts_controller.rb:show",
+      "target": "function:app/controllers/posts_controller.rb:set_no_cache_headers",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "class:app/models/post.rb:Post",
+      "target": "function:app/models/post.rb:self.find_by_slug_or_id!",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "Post 모델이 find_by_slug_or_id! 를 정의한다"
+    },
+    {
+      "source": "class:app/models/post.rb:Post",
+      "target": "function:app/models/post.rb:self.yearly_archive_counts",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "Post 모델이 yearly_archive_counts 를 정의한다"
+    },
+    {
+      "source": "class:app/models/post.rb:Post",
+      "target": "function:app/models/post.rb:previous_post",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "Post 모델이 previous_post 를 정의한다"
+    },
+    {
+      "source": "class:app/models/post.rb:Post",
+      "target": "function:app/models/post.rb:next_post",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "Post 모델이 next_post 를 정의한다"
+    },
+    {
+      "source": "class:app/models/post.rb:Post",
+      "target": "function:app/models/post.rb:tag_list",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "Post 모델이 tag_list 를 정의한다"
+    },
+    {
+      "source": "class:app/models/post.rb:Post",
+      "target": "function:app/models/post.rb:cover_image_caption",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "Post 모델이 cover_image_caption 를 정의한다"
+    },
+    {
+      "source": "class:app/controllers/posts_controller.rb:PostsController",
+      "target": "function:app/controllers/posts_controller.rb:new",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "PostsController 가 new 액션을 정의한다"
+    },
+    {
+      "source": "class:app/controllers/posts_controller.rb:PostsController",
+      "target": "function:app/controllers/posts_controller.rb:edit",
+      "type": "contains",
+      "weight": 1.0,
+      "direction": "forward",
+      "description": "PostsController 가 edit 액션을 정의한다"
+    }
+  ],
+  "version": "1.0.0",
+  "project": {
+    "name": "blog-with-rails",
+    "languages": [
+      "css",
+      "dockerfile",
+      "erb",
+      "html",
+      "javascript",
+      "json",
+      "markdown",
+      "ruby",
+      "yaml"
+    ],
+    "frameworks": [
+      "Rails",
+      "Docker",
+      "GitHub Actions"
+    ],
+    "description": "Rails 8 기반의 모던 블로그 애플리케이션으로, Turbo/Stimulus 프론트엔드와 TinyMCE 에디터, 태그 시스템, 세션 기반 관리자 인증을 제공하며 Docker와 Kamal로 배포됩니다. 참고: 이 프로젝트는 100개가 넘는 소스 파일을 포함하므로, 더 빠른 분석을 위해 하위 디렉터리로 범위를 좁히는 것을 고려하세요.",
+    "analyzedAt": "2026-08-01T10:12:18.181775Z",
+    "gitCommitHash": "f970d0e415dd1cf628297524f798dd7c433230de"
+  },
+  "layers": [
+    {
+      "id": "layer:api",
+      "name": "API 레이어",
+      "description": "HTTP 요청을 처리하는 Rails 컨트롤러 계층으로, 게시글 CRUD와 공개/관리자 가시성 스코프(posts), 세션 기반 관리자 인증과 brute-force 잠금(sessions), 커스텀 에러 페이지(errors), Active Storage 기반 이미지 업로드(uploads)를 담당한다.",
+      "nodeIds": [
+        "file:app/controllers/application_controller.rb",
+        "file:app/controllers/concerns/.keep",
+        "file:app/controllers/errors_controller.rb",
+        "file:app/controllers/posts_controller.rb",
+        "file:app/controllers/sessions_controller.rb",
+        "file:app/controllers/uploads_controller.rb"
+      ]
+    },
+    {
+      "id": "layer:ui",
+      "name": "UI 레이어",
+      "description": "ERB 뷰 템플릿과 레이아웃, Kaminari 페이지네이션 및 게시글 카드 partial, 반응형 이미지 태그를 생성하는 뷰 헬퍼, importmap으로 로드되는 Stimulus 컨트롤러와 TinyMCE·PrismJS·MathJax 초기화 모듈, 전역 CSS, public/ 정적 에러 페이지까지 사용자에게 보이는 화면 전체를 구성한다.",
+      "nodeIds": [
+        "document:public/robots.txt",
+        "file:app/assets/images/.keep",
+        "file:app/assets/stylesheets/site.css",
+        "file:app/helpers/application_helper.rb",
+        "file:app/helpers/image_helper.rb",
+        "file:app/helpers/posts_helper.rb",
+        "file:app/javascript/application.js",
+        "file:app/javascript/controllers/application.js",
+        "file:app/javascript/controllers/index.js",
+        "file:app/javascript/controllers/search_controller.js",
+        "file:app/javascript/init.js",
+        "file:app/views/active_storage/blobs/_blob.html.erb",
+        "file:app/views/errors/internal_server.html.erb",
+        "file:app/views/errors/not_found.html.erb",
+        "file:app/views/errors/unprocessable.html.erb",
+        "file:app/views/kaminari/_gap.html.erb",
+        "file:app/views/kaminari/_next_page.html.erb",
+        "file:app/views/kaminari/_page.html.erb",
+        "file:app/views/kaminari/_paginator.html.erb",
+        "file:app/views/kaminari/_prev_page.html.erb",
+        "file:app/views/layouts/action_text/contents/_content.html.erb",
+        "file:app/views/layouts/application.html.erb",
+        "file:app/views/layouts/mailer.html.erb",
+        "file:app/views/layouts/mailer.text.erb",
+        "file:app/views/posts/_form.html.erb",
+        "file:app/views/posts/_post.html.erb",
+        "file:app/views/posts/_post_card.html.erb",
+        "file:app/views/posts/_post_meta.html.erb",
+        "file:app/views/posts/_post_navigation.html.erb",
+        "file:app/views/posts/_recommended_posts.html.erb",
+        "file:app/views/posts/_sidebar.html.erb",
+        "file:app/views/posts/edit.html.erb",
+        "file:app/views/posts/index.html.erb",
+        "file:app/views/posts/new.html.erb",
+        "file:app/views/posts/show.html.erb",
+        "file:app/views/posts/show_all.html.erb",
+        "file:app/views/pwa/manifest.json.erb",
+        "file:app/views/pwa/service-worker.js",
+        "file:app/views/sessions/new.html.erb",
+        "file:public/400.html",
+        "file:public/404.html",
+        "file:public/406-unsupported-browser.html",
+        "file:public/422.html",
+        "file:public/500.html"
+      ]
+    },
+    {
+      "id": "layer:data",
+      "name": "데이터 레이어",
+      "description": "Post·Tag·Admin ActiveRecord 모델(Action Text 본문과 Active Storage WebP variant 정의 포함)과 db/ 마이그레이션, schema.rb 스냅샷, Solid Cache/Queue/Cable 스키마, 시드 데이터로 구성된 영속성 계층이다.",
+      "nodeIds": [
+        "file:app/models/admin.rb",
+        "file:app/models/application_record.rb",
+        "file:app/models/concerns/.keep",
+        "file:app/models/post.rb",
+        "file:app/models/tag.rb",
+        "file:db/cable_schema.rb",
+        "file:db/cache_schema.rb",
+        "file:db/migrate/20251122082531_create_posts.rb",
+        "file:db/migrate/20251122082559_create_active_storage_tables.active_storage.rb",
+        "file:db/migrate/20251122082560_create_action_text_tables.action_text.rb",
+        "file:db/migrate/20251125033932_add_tags_to_posts.rb",
+        "file:db/migrate/20251130051704_add_slug_and_category_to_posts.rb",
+        "file:db/migrate/20260319025507_create_tags_and_posts_tags.rb",
+        "file:db/migrate/20260319034444_remove_tags_string_from_posts.rb",
+        "file:db/migrate/20260324033356_create_admins.rb",
+        "file:db/migrate/20260731120000_add_published_at_index_to_posts.rb",
+        "file:db/migrate/20260801060000_add_word_count_to_posts.rb",
+        "file:db/queue_schema.rb",
+        "file:db/schema.rb",
+        "file:db/seeds.rb"
+      ]
+    },
+    {
+      "id": "layer:service",
+      "name": "서비스 레이어",
+      "description": "Active Job·Action Mailer 기본 클래스와 SQLite 데이터 임포트, 태그 정규화 등을 수행하는 lib/tasks의 Rake 태스크로 이루어진, 요청-응답 흐름 밖에서 동작하는 백그라운드 및 일회성 작업 코드이다.",
+      "nodeIds": [
+        "file:app/jobs/application_job.rb",
+        "file:app/mailers/application_mailer.rb",
+        "file:lib/tasks/.keep",
+        "file:lib/tasks/import_from_sqlite.rake",
+        "file:lib/tasks/migrate_tags.rake"
+      ]
+    },
+    {
+      "id": "layer:config",
+      "name": "설정 레이어",
+      "description": "config.ru → boot → application → environment로 이어지는 Rails 부팅 체인과 라우팅, 환경별 설정, Puma·importmap·스토리지·Solid Queue 설정, CSP·보안 헤더·Cloudflare 프록시·Action Text sanitizer 같은 initializer, Gemfile 등 의존성 매니페스트를 포함한다.",
+      "nodeIds": [
+        "config:config/cable.yml",
+        "config:config/cache.yml",
+        "config:config/database.yml",
+        "config:config/locales/en.yml",
+        "config:config/queue.yml",
+        "config:config/recurring.yml",
+        "config:config/storage.yml",
+        "file:.gitattributes",
+        "file:.ruby-version",
+        "file:Gemfile",
+        "file:Rakefile",
+        "file:config.ru",
+        "file:config/application.rb",
+        "file:config/boot.rb",
+        "file:config/credentials.yml.enc",
+        "file:config/environment.rb",
+        "file:config/environments/development.rb",
+        "file:config/environments/production.rb",
+        "file:config/environments/test.rb",
+        "file:config/importmap.rb",
+        "file:config/initializers/action_text.rb",
+        "file:config/initializers/assets.rb",
+        "file:config/initializers/cloudflare.rb",
+        "file:config/initializers/content_security_policy.rb",
+        "file:config/initializers/filter_parameter_logging.rb",
+        "file:config/initializers/inflections.rb",
+        "file:config/initializers/kaminari_config.rb",
+        "file:config/initializers/security_headers.rb",
+        "file:config/puma.rb",
+        "file:config/routes.rb"
+      ]
+    },
+    {
+      "id": "layer:infrastructure",
+      "name": "인프라 레이어",
+      "description": "멀티 스테이지 Dockerfile(base/build)과 .dockerignore, Kamal 배포 설정 및 배포 라이프사이클 hook 스크립트, 시크릿 정의, Thruster 프록시·Solid Queue 워커·컨테이너 엔트리포인트 실행 바이너리로 프로덕션 배포와 런타임 구동을 정의한다.",
+      "nodeIds": [
+        "config:config/deploy.yml",
+        "file:.kamal/hooks/docker-setup.sample",
+        "file:.kamal/hooks/post-app-boot.sample",
+        "file:.kamal/hooks/post-deploy.sample",
+        "file:.kamal/hooks/post-proxy-reboot.sample",
+        "file:.kamal/hooks/pre-app-boot.sample",
+        "file:.kamal/hooks/pre-build.sample",
+        "file:.kamal/hooks/pre-connect.sample",
+        "file:.kamal/hooks/pre-deploy.sample",
+        "file:.kamal/hooks/pre-proxy-reboot.sample",
+        "file:.kamal/secrets",
+        "file:bin/docker-entrypoint",
+        "file:bin/jobs",
+        "file:bin/kamal",
+        "file:bin/thrust",
+        "service:.dockerignore",
+        "service:Dockerfile",
+        "service:Dockerfile:base",
+        "service:Dockerfile:build"
+      ]
+    },
+    {
+      "id": "layer:dev-tooling",
+      "name": "개발 도구 및 CI/CD 레이어",
+      "description": "GitHub Actions 워크플로와 Dependabot 설정, RuboCop·Brakeman·bundler-audit 정책 파일, 이를 한 번에 실행하는 bin/check-code·bin/ci와 config/ci.rb 파이프라인 정의, 로컬 개발 구동용 binstub과 Procfile.dev, 폰트 서브셋팅 빌드 유틸리티로 구성된 코드 품질 및 자동화 툴체인이다.",
+      "nodeIds": [
+        "config:.github/dependabot.yml",
+        "config:.rubocop.yml",
+        "config:config/bundler-audit.yml",
+        "file:Procfile.dev",
+        "file:bin/brakeman",
+        "file:bin/bundler-audit",
+        "file:bin/check-code",
+        "file:bin/ci",
+        "file:bin/dev",
+        "file:bin/importmap",
+        "file:bin/rails",
+        "file:bin/rake",
+        "file:bin/rubocop",
+        "file:bin/setup",
+        "file:config/brakeman.ignore",
+        "file:config/ci.rb",
+        "file:script/.keep",
+        "file:script/subset_fonts.py",
+        "pipeline:.github/workflows/ci.yml"
+      ]
+    },
+    {
+      "id": "layer:test",
+      "name": "테스트 레이어",
+      "description": "Minitest 기반 컨트롤러·모델·헬퍼 테스트와 fixture, 인증 throttling·업로드 검증·이미지 헬퍼 등 보안 및 성능 시나리오 검증, SimpleCov 커버리지 설정이 담긴 test_helper와 시스템 테스트 베이스 클래스를 포함한다.",
+      "nodeIds": [
+        "config:test/fixtures/action_text/rich_texts.yml",
+        "config:test/fixtures/admins.yml",
+        "config:test/fixtures/posts.yml",
+        "file:test/application_system_test_case.rb",
+        "file:test/controllers/.keep",
+        "file:test/controllers/errors_controller_test.rb",
+        "file:test/controllers/posts_controller_test.rb",
+        "file:test/controllers/sessions_controller_test.rb",
+        "file:test/controllers/uploads_controller_test.rb",
+        "file:test/fixtures/files/.keep",
+        "file:test/helpers/.keep",
+        "file:test/helpers/image_helper_test.rb",
+        "file:test/integration/.keep",
+        "file:test/mailers/.keep",
+        "file:test/models/.keep",
+        "file:test/models/post_test.rb",
+        "file:test/models/tag_test.rb",
+        "file:test/system/.keep",
+        "file:test/test_helper.rb"
+      ]
+    },
+    {
+      "id": "layer:documentation",
+      "name": "문서 레이어",
+      "description": "README의 프로젝트 개요·설치 가이드와 CLAUDE.md의 아키텍처 규약·서브시스템 설명 등 코드가 아닌 산문 형태의 프로젝트 지식을 모은 계층이다.",
+      "nodeIds": [
+        "document:CLAUDE.md",
+        "document:README.md"
+      ]
+    }
+  ],
+  "tour": [
+    {
+      "order": 1,
+      "title": "프로젝트 개요와 설계 규약",
+      "description": "README 로 이 프로젝트가 무엇인지 — Rails 8.1 + Ruby 3.4 기반의 개인 블로그, Hotwire(Turbo/Stimulus)와 importmap 으로 Node 빌드 없이 동작하고 Kamal/Docker 로 배포된다는 큰 그림을 먼저 잡는다. 이어서 CLAUDE.md 는 README 가 다루지 않는 규약, 즉 공개 범위 스코프, 코드 블록 Base64 파이프라인, 이미지 서빙 경로 같은 비직관적인 서브시스템의 배경을 설명한다. 이 두 문서가 앞으로 이어질 모든 단계의 지도 역할을 한다.",
+      "nodeIds": [
+        "document:README.md",
+        "document:CLAUDE.md"
+      ]
+    },
+    {
+      "order": 2,
+      "title": "Rails 부팅 체인",
+      "description": "Rack 진입점인 config.ru 에서 시작해 environment.rb → application.rb → boot.rb 로 이어지는 부팅 순서를 따라간다. 핵심은 application.rb 로, load_defaults 8.0 과 lib 오토로드 범위를 정하고 Active Storage 의 vips variant 프로세서·WebP 허용 타입을 설정하며, resolve_model_to_route 를 :rails_storage_proxy 로 지정해 이미지를 앱이 직접 프록시하도록 만든다. 또 exceptions_app 을 라우터로 넘겨 정적 404/500 대신 ErrorsController 가 동적 오류 페이지를 렌더하게 한다.",
+      "nodeIds": [
+        "file:config.ru",
+        "file:config/environment.rb",
+        "file:config/application.rb",
+        "file:config/boot.rb"
+      ],
+      "languageLesson": "Rails 부팅은 항상 boot.rb(Bundler 설정) → application.rb(앱 클래스 정의) → environment.rb(initialize! 호출) 순서로 진행된다. config.ru 는 이 체인을 require 한 뒤 Rails.application 을 Rack 앱으로 run 할 뿐이므로, 전역 설정을 넣을 곳은 언제나 application.rb 또는 config/initializers 다."
+    },
+    {
+      "order": 3,
+      "title": "라우팅: URL 에서 컨트롤러까지",
+      "description": "routes.rb 는 요청이 어느 컨트롤러 액션으로 흘러가는지 한 눈에 보여주는 목차다. posts 리소스를 중심으로 검색·태그·연도별 아카이브 같은 커스텀 컬렉션 라우트가 붙고, 세션 로그인/로그아웃, TinyMCE 업로드 엔드포인트, 그리고 exceptions_app 이 사용하는 /404·/422·/500 오류 라우트가 함께 정의된다. 게시글은 slug 또는 숫자 id 둘 다로 접근되므로 라우트 파라미터가 곧바로 모델의 조회 규칙과 맞물린다.",
+      "nodeIds": [
+        "file:config/routes.rb",
+        "file:app/controllers/errors_controller.rb"
+      ],
+      "languageLesson": "Rails 의 convention over configuration 은 라우팅에서 가장 잘 드러난다. `resources :posts` 한 줄이 index/show/new/create/edit/update/destroy 7개 라우트를 만들고, 이름 규칙만으로 PostsController 와 posts 테이블까지 연결된다."
+    },
+    {
+      "order": 4,
+      "title": "PostsController 와 공개 범위 분기",
+      "description": "이 앱에서 가장 중요한 컨트롤러이자 보안 경계다. post_scope 가 축이 되어 관리자에게는 Post.all 을, 일반 방문자에게는 Post.published(published_at <= now, 즉 미래 날짜는 예약 발행)만 보여주며, 이 스코프를 우회하면 곧바로 미공개 글이 노출된다. 목록 계열 액션은 태그·리치 텍스트·커버 이미지를 함께 eager load 하는 listing_scope 를 써서 N+1 쿼리를 막고, index/search/tag/archive 는 조건에 따라 show_all 템플릿으로 갈라진다.",
+      "nodeIds": [
+        "file:app/controllers/posts_controller.rb",
+        "file:config/initializers/kaminari_config.rb"
+      ],
+      "languageLesson": "ActiveRecord scope 는 지연 평가되는 relation 을 반환하므로 `post_scope.includes(:tags).page(params[:page])` 처럼 계속 이어 붙일 수 있다. 가시성 판정을 컨트롤러 곳곳에 흩뿌리지 않고 단일 scope 메서드로 모으는 것이 권한 누수를 막는 가장 값싼 방법이다."
+    },
+    {
+      "order": 5,
+      "title": "도메인 모델: Post 와 Tag",
+      "description": "Post 는 Action Text 본문, Active Storage 커버 이미지와 WebP variant 정의, 발행·검색·아카이브 scope, 그리고 slug 생성을 모두 품은 중심 모델이다. 영문 제목은 parameterize 로 slug 를 만들지만 한글 제목은 빈 문자열이 되어 숫자 id 로 폴백한다는 점이 to_param 설계의 핵심이다. read_time 은 더 이상 본문을 파싱하지 않고 before_save 에서 채워 둔 posts.word_count 컬럼을 읽으며, 이를 위한 마이그레이션이 기존 글을 한 번만 읽어 백필한다. Tag 는 다대다 조인으로 연결되어 태그 페이지와 사이드바를 지탱한다.",
+      "nodeIds": [
+        "file:app/models/post.rb",
+        "file:app/models/tag.rb",
+        "file:db/migrate/20260801060000_add_word_count_to_posts.rb"
+      ],
+      "languageLesson": "`before_save` 콜백으로 파생 값을 컬럼에 미리 계산해 두는 것은 읽기 편중 워크로드의 정석적인 최적화다. 목록 카드 20개마다 Action Text 본문을 조회하던 비용이 컬럼 하나로 사라지지만, 대신 계산 규칙이 바뀌면 마이그레이션으로 백필해야 하는 책임이 생긴다."
+    },
+    {
+      "order": 6,
+      "title": "데이터베이스 스키마와 이중 DB 구성",
+      "description": "schema.rb 는 posts·tags·admins 와 Action Text·Active Storage 부속 테이블까지 현재 스키마 전체를 보여준다. database.yml 은 이 프로젝트의 특이점을 담는데, 개발/테스트는 SQLite 지만 프로덕션 primary 는 Supabase PostgreSQL 이며 transaction pooler 호환을 위해 prepared_statements: false 가 반드시 필요하다. 동시에 Solid Cache/Queue/Cable 은 프로덕션에서도 별도의 로컬 SQLite 파일을 쓰므로, 하나의 앱이 서로 다른 엔진의 데이터베이스 네 개를 동시에 다룬다.",
+      "nodeIds": [
+        "file:db/schema.rb",
+        "config:config/database.yml",
+        "file:db/cache_schema.rb",
+        "file:db/queue_schema.rb",
+        "file:db/seeds.rb"
+      ],
+      "languageLesson": "Rails 의 multiple databases 기능은 database.yml 에서 환경별로 여러 이름 붙은 연결(primary, cache, queue, cable)을 선언하고 각각 별도 schema 파일을 갖게 한다. `migrations_paths` 를 분리해 두면 앱 마이그레이션과 인프라용 스키마가 서로 섞이지 않는다."
+    },
+    {
+      "order": 7,
+      "title": "관리자 인증과 캐시 기반 로그인 스로틀링",
+      "description": "Devise 없이 has_secure_password 를 쓰는 Admin 모델 하나와 SessionsController 로 인증이 끝난다. 브루트포스 방어는 세션(쿠키)이 아니라 서버 측 캐시에 IP 별 로그인 실패 횟수를 세는 방식인데, 쿠키에 두면 공격자가 쿠키를 버리는 것만으로 우회할 수 있기 때문이고 성공 시에는 카운터를 지운다. Rails 8 의 rate_limit 을 쓰지 않은 이유도 같은 맥락으로, 성공 요청까지 세면 계정이 하나뿐인 소유자가 스스로 잠기게 된다. 로그인에 성공하면 reset_session 으로 세션 고정 공격을 차단하고, ApplicationController 가 12시간 세션 타임아웃을 강제한다.",
+      "nodeIds": [
+        "file:app/controllers/sessions_controller.rb",
+        "file:app/models/admin.rb",
+        "file:app/views/sessions/new.html.erb"
+      ],
+      "languageLesson": "`has_secure_password` 는 bcrypt 해시를 password_digest 컬럼에 저장하고 authenticate 메서드를 만들어 준다. 여기에 admin 네임스페이스를 따로 두지 않고 write 액션에만 `authenticate_admin!` before_action 을 거는 것이 이 앱의 권한 모델 전부다."
+    },
+    {
+      "order": 8,
+      "title": "뷰 계층과 게시글 렌더링",
+      "description": "application.html.erb 레이아웃이 메타/OG 태그, importmap 스크립트, 헤더·푸터·검색 UI 를 조립하고, 그 안에서 show 와 show_all 템플릿이 상세 화면과 목록 화면을 나눠 맡는다. 목록은 _post_card partial 을 반복하는데, 4단계에서 본 listing_scope 가 미리 로드해 둔 태그·커버 이미지를 여기서 소비하므로 뷰와 스코프가 한 쌍으로 움직인다. posts_helper 는 카드 요약, 날짜 표기, 카테고리 라벨 같은 표현 로직을 템플릿 밖으로 빼낸다.",
+      "nodeIds": [
+        "file:app/views/layouts/application.html.erb",
+        "file:app/views/posts/show.html.erb",
+        "file:app/views/posts/show_all.html.erb",
+        "file:app/views/posts/_post_card.html.erb",
+        "file:app/helpers/posts_helper.rb"
+      ],
+      "languageLesson": "ERB partial 은 `render partial: 'post_card', collection: @posts` 형태로 부르면 Rails 가 컬렉션 렌더링을 한 번에 처리해 개별 render 호출보다 빠르다. 다만 partial 안에서 연관을 처음 건드리면 즉시 N+1 이 되므로, 필요한 연관은 반드시 컨트롤러 스코프에서 eager load 해야 한다."
+    },
+    {
+      "order": 9,
+      "title": "코드 블록 Base64 파이프라인",
+      "description": "이 프로젝트에서 가장 비직관적인 서브시스템이다. Action Text 의 Nokogiri sanitizer 가 <pre><code> 안의 HTML 엔티티를 망가뜨리기 때문에, 저장 시점에 PostsController 가 코드 블록 내용을 BASE64: 접두사로 인코딩하고 렌더 시점에 Post#rendered_content 가 디코딩해 html_safe 로 돌려준다. 편집 화면에서는 init.js 가 TinyMCE 로 되돌릴 때 다시 디코딩하고 레거시 원본 HTML 은 재인코딩한다. 저장·렌더·편집 세 방향이 항상 짝을 이뤄야 하며, action_text initializer 는 테이블·svg·data-turbo 를 sanitizer 허용 목록에 추가한다.",
+      "nodeIds": [
+        "file:config/initializers/action_text.rb",
+        "file:app/javascript/init.js",
+        "file:app/views/posts/_form.html.erb"
+      ],
+      "languageLesson": "`html_safe` 는 문자열을 검증하지 않고 이스케이프를 끄기만 한다. 따라서 이렇게 직접 디코딩한 HTML 을 출력할 때는 신뢰 경계가 어디인지(여기서는 관리자만 글을 쓴다는 전제) 분명히 해 두어야 한다."
+    },
+    {
+      "order": 10,
+      "title": "프론트엔드: importmap 과 조건부 라이브러리 로드",
+      "description": "번들러가 없다. importmap.rb 가 ESM 모듈을 브라우저에 직접 매핑하고, application.js 가 Turbo 와 Stimulus 를 기동하며 controllers/index.js 가 Stimulus 컨트롤러를 등록한다. Prism·Mermaid·MathJax 는 모든 페이지에 싣지 않고 application_helper 의 content_library? 판정을 통해 실제로 그 문법이 등장하는 글에서만 내려받으며, 에디터가 TinyMCE 로 대체된 뒤 Trix/Action Text JS 는 제거됐다. search_controller.js 는 전형적인 Stimulus 컨트롤러가 어떻게 생겼는지 보여 주는 예다.",
+      "nodeIds": [
+        "file:config/importmap.rb",
+        "file:app/javascript/application.js",
+        "file:app/javascript/controllers/index.js",
+        "file:app/helpers/application_helper.rb",
+        "file:app/javascript/controllers/search_controller.js"
+      ],
+      "languageLesson": "importmap 은 빌드 산출물 대신 브라우저 네이티브 ES modules 를 쓰므로 트리 셰이킹이 없다. 그래서 '무엇을 언제 로드할지'를 번들러가 아니라 서버 사이드 헬퍼가 결정하게 되고, 이 앱의 content_library? 가 바로 그 역할을 한다."
+    },
+    {
+      "order": 11,
+      "title": "이미지 서빙의 두 경로",
+      "description": "이미지는 두 갈래로만 흐른다. 첫째는 Post 의 Active Storage 커버 이미지로, 모델에 정의된 :thumbnail~:hero WebP variant 를 image_helper 가 optimized_image_tag/responsive_image_tag/picture_tag 로 렌더하며 blob 메타데이터에서 실제 크기를 계산해 CLS 를 줄인다. 둘째는 본문 이미지로, TinyMCE 가 UploadsController 에 올리면 MIME 타입과 10MB 제한을 검증한 뒤 variant srcset 을 JSON 으로 돌려준다. 2단계에서 본 rails_storage_proxy 설정 덕분에 두 경로 모두 앱이 바이트를 직접 내려주며, redirect 방식일 때의 302 왕복과 private Cache-Control 때문에 Cloudflare 가 캐시하지 못하던 문제가 사라졌다.",
+      "nodeIds": [
+        "file:app/helpers/image_helper.rb",
+        "file:app/controllers/uploads_controller.rb",
+        "config:config/storage.yml",
+        "file:test/helpers/image_helper_test.rb"
+      ],
+      "languageLesson": "Active Storage 의 variant 는 요청 시점에 lazily 생성되어 저장되므로 첫 요청만 vips 처리 비용을 낸다. LCP 대상 이미지 하나에만 fetchpriority: high 와 lazy: false 를 주는 것이 핵심이며, 전부에 걸면 우선순위 신호가 무의미해진다."
+    },
+    {
+      "order": 12,
+      "title": "전송 성능: HTTP 캐싱과 폰트 서브셋",
+      "description": "공개 응답은 fresh_when/stale? 로 ETag 를 붙이고 관리자 응답은 no-store 를 받는데, 여기엔 두 개의 실전 함정이 녹아 있다. ApplicationController 는 Rails 기본 Cache-Control 지시자를 직접 써 넣는다 — after_action 이 handle_conditional_get! 보다 먼저 돌아 기본값이 적용되지 못하기 때문이다. 그리고 index 의 ETag 는 relation 이 아니라 cache_version 과 파라미터로 만드는데, relation 의 to_sql 에는 Time.current 가 박혀 매 요청 값이 달라졌기 때문이다. 같은 맥락의 전송 최적화로 script/subset_fonts.py 가 Lato woff2 를 라틴 범위로 줄여 200KB 대를 40KB 대로 낮추면서, 사이트에 실제로 쓰이는 코드포인트가 빠지지 않았는지 검사한다.",
+      "nodeIds": [
+        "file:app/controllers/application_controller.rb",
+        "file:config/environments/production.rb",
+        "config:config/cache.yml",
+        "file:script/subset_fonts.py"
+      ],
+      "languageLesson": "ETag 는 '같은 입력이면 같은 값'이어야 조건부 GET 이 성립한다. 캐시 키를 만들 때 현재 시각이나 객체 주소처럼 요청마다 달라지는 값이 섞이면 304 가 영원히 나오지 않으므로, relation 대신 maximum(:updated_at) 기반 cache_version 같은 안정적인 재료를 써야 한다."
+    },
+    {
+      "order": 13,
+      "title": "보안 헤더, CSP, Cloudflare 프록시",
+      "description": "CSP 는 아직 report-only 인데, TinyMCE·GA·MathJax 가 unsafe_inline/unsafe_eval 을 요구하기 때문이며 이는 의도된 현재 상태다. security_headers initializer 는 프로덕션에서만 붙는 헤더를 담당하고, cloudflare initializer 는 Cloudflare IP 대역을 신뢰 프록시로 등록해 7단계의 로그인 실패 카운팅이 프록시 IP 가 아닌 실제 클라이언트 IP 를 보게 만든다. brakeman.ignore 는 이미 검토를 마친 정적 분석 경고 목록이므로, 스캐너 결과를 '고치기' 전에 여기부터 확인해야 한다.",
+      "nodeIds": [
+        "file:config/initializers/content_security_policy.rb",
+        "file:config/initializers/security_headers.rb",
+        "file:config/initializers/cloudflare.rb",
+        "file:config/brakeman.ignore"
+      ],
+      "languageLesson": "CSP 를 report-only 로 두는 것은 정책을 강제하지 않고 위반만 수집하는 단계다. 인라인 스크립트를 요구하는 서드파티 위젯을 걷어내기 전에 enforce 로 바꾸면 사이트가 그대로 깨지므로, 완화 항목을 하나씩 제거한 뒤 전환하는 순서를 지켜야 한다."
+    },
+    {
+      "order": 14,
+      "title": "테스트와 품질 게이트",
+      "description": "Minitest 기반의 병렬 테스트가 SimpleCov 브랜치 커버리지와 함께 돌아가며, test_helper 의 sign_in_as_admin 헬퍼가 관리자 전용 액션 테스트의 공통 진입점이다. posts_controller_test 는 공개 범위 스코프가 미공개 글을 새게 하지 않는지, sessions_controller_test 는 실패 횟수 기반 잠금이 소유자를 잠그지 않는지 같은 보안 시나리오를 직접 검증한다. bin/check-code 는 Brakeman → RuboCop → 전체 테스트를 묶은 push 전 게이트이고, GitHub Actions 워크플로가 여기에 bundler-audit·importmap audit·시드 재적재까지 더해 CI 에서 재현한다.",
+      "nodeIds": [
+        "file:test/test_helper.rb",
+        "file:test/controllers/posts_controller_test.rb",
+        "file:test/controllers/sessions_controller_test.rb",
+        "file:bin/check-code",
+        "pipeline:.github/workflows/ci.yml"
+      ],
+      "languageLesson": "Rails 의 fixtures 는 테스트 시작 전 트랜잭션 안에서 통째로 적재되고 각 테스트 후 롤백된다. 다만 Solid Cache 처럼 DB 밖 상태를 공유하는 요소는 롤백되지 않으므로, 캐시 기반 스로틀링을 테스트할 때는 setup 에서 캐시를 명시적으로 비워야 한다."
+    },
+    {
+      "order": 15,
+      "title": "컨테이너화와 Kamal 배포",
+      "description": "마지막으로 지금까지 본 앱이 어떻게 프로덕션에 도달하는지 본다. 멀티 스테이지 Dockerfile 은 build 스테이지에서 gem 을 빌드하고 자산을 컴파일한 뒤 실행에 필요한 것만 base 이미지로 옮기며, libvips 를 명시적으로 설치한다(ruby-vips 가 FFI 로 로드하므로 없으면 부팅조차 되지 않는다). deploy.yml 은 Kamal 이 Thruster 프록시와 SOLID_QUEUE_IN_PUMA 워커를 어떻게 띄울지 정의하고, .kamal/secrets 가 RAILS_MASTER_KEY·ADMIN_* ·SUPABASE_DB_PASSWORD 를 주입한다. docker-entrypoint 는 컨테이너 기동 시 DB 준비를 처리한다.",
+      "nodeIds": [
+        "service:Dockerfile",
+        "config:config/deploy.yml",
+        "file:.kamal/secrets",
+        "file:bin/docker-entrypoint",
+        "service:.dockerignore"
+      ],
+      "languageLesson": "멀티 스테이지 빌드에서 레이어 순서는 캐시 효율을 좌우한다. OS 패키지 → Gemfile/Gemfile.lock 복사 후 bundle install → 애플리케이션 코드 복사 순으로 두면 코드만 바뀐 배포에서 gem 설치 레이어를 그대로 재사용한다. .dockerignore 로 .git·.env·master.key 를 빌드 컨텍스트에서 빼는 것은 속도이자 보안 조치다."
+    }
+  ]
+}

--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,0 +1,6 @@
+{
+  "lastAnalyzedAt": "2026-08-01T10:14:16.292830Z",
+  "gitCommitHash": "f970d0e415dd1cf628297524f798dd7c433230de",
+  "version": "1.0.0",
+  "analyzedFiles": 162
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,104 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Rails 8.1 blog application (Ruby 3.4.5). Hotwire (Turbo + Stimulus) with importmap — no Node/bundler; custom CSS (no Tailwind). Action Text + TinyMCE for authoring, Active Storage + libvips for images, Kaminari for pagination. Deployed with Kamal/Docker behind Cloudflare; production DB is Supabase PostgreSQL.
+
+## Commands
+
+```bash
+bin/setup                # install deps, prepare DB
+bin/dev                  # dev server via foreman (http://localhost:3000)
+bin/rails db:seed        # admin account + sample posts
+
+# Tests (minitest, parallel workers, SimpleCov branch coverage → coverage/)
+bin/rails test                                    # unit + integration
+bin/rails test:system                             # Capybara/Selenium — needs Chrome
+bin/rails test test/models/post_test.rb           # single file
+bin/rails test test/models/post_test.rb:42        # single test by line
+
+# Quality gates
+bin/check-code           # pre-push gate: Brakeman → RuboCop → all tests
+bin/ci                   # full local CI (adds bundler-audit, importmap audit, seed replant)
+bin/rubocop -a           # style (rubocop-rails-omakase) with autocorrect
+bin/brakeman --no-pager  # security static analysis (suppressions: config/brakeman.ignore)
+```
+
+Environment notes:
+
+- Host is Windows; `bin/*` are POSIX shell scripts — run them from Git Bash. `.gitattributes` forces LF on `bin/*` (CRLF breaks shebangs in Docker builds).
+- Booting the app requires the libvips system library (ruby-vips loads it via FFI). CI and the Dockerfile install it explicitly.
+- `.env` (dotenv-rails) supplies dev env vars like `TINYMCE_API_KEY`. Production requires `ADMIN_EMAIL`/`ADMIN_PASSWORD` — `db/seeds.rb` raises without them to prevent a default-credential admin.
+
+## Architecture
+
+### Database topology
+
+- development/test: SQLite (`storage/*.sqlite3`). Production primary: Supabase PostgreSQL via transaction pooler (`prepared_statements: false` is required for pooler compatibility).
+- Solid Cache/Queue/Cable always use separate local SQLite databases, even in production (`SOLID_QUEUE_IN_PUMA=true` runs jobs inside Puma).
+
+### Admin auth (no Devise)
+
+Single `Admin` model (`has_secure_password`); session-based login in `SessionsController` with `reset_session` on login. `ApplicationController#admin_signed_in?` enforces a 12-hour session timeout. There is no admin namespace — admin capability is `authenticate_admin!` on write actions of `PostsController` and `UploadsController`.
+
+Login throttling counts **failed** attempts per IP in `Rails.cache` (Solid Cache in production) and clears the counter on success. Two things to preserve if you touch it: the count must not live in the session, because a client that discards cookies would reset it; and Rails 8's `rate_limit` is deliberately unused, because it counts every request including successes and offers no reset hook, which locks the sole owner out of their own site. `remote_ip` is the real client IP thanks to the Cloudflare trusted-proxy ranges in `config/initializers/cloudflare.rb`.
+
+### Post visibility and caching
+
+`PostsController#post_scope` is the pivot: admins see `Post.all`, the public sees `Post.published` (`published_at <= now`, so future dates are scheduled posts). Always go through this scope (and `Post.find_by_slug_or_id!`, which preserves the current scope) — bypassing it leaks unpublished posts. HTTP caching splits on the same check: public responses use `fresh_when`/`stale?` ETags, admin responses get no-store headers.
+
+Two caching details are load-bearing and easy to undo by accident:
+
+- `ApplicationController::CONDITIONAL_GET_CACHE_CONTROL` spells out `max-age=0, private, must-revalidate` by hand. Rails only fills those in from `handle_conditional_get!` when `Cache-Control` is still unset at commit, and the `after_action` that appends `no-transform` runs earlier — so touching the header at all (raw or via `cache_control[:extras]`) suppresses the default and drops public HTML into RFC 9111 heuristic freshness.
+- `#index` builds its ETag from `@posts.cache_version` plus the params that select the response, **not** from the relation. `Relation#cache_key` digests `to_sql`, and `Post.published` is a string condition, so `Time.current` is inlined down to the microsecond and the ETag would change on every request.
+
+Changing only a post's tags does not dirty the record, so `Post#tag_list=` touches it — otherwise the ETag never moves and readers keep the old badges.
+
+Posts are addressed by slug or numeric id (`to_param`): English titles auto-generate a slug via `parameterize`; Korean titles produce an empty slug and fall back to id.
+
+### Code-block Base64 pipeline (most non-obvious subsystem)
+
+Action Text's sanitizer (Nokogiri) corrupts HTML entities inside `<pre><code>`. The workaround spans four files and both directions must stay in sync:
+
+1. **Save**: `PostsController#encode_code_blocks` Base64-encodes code-block innards (`BASE64:...`) before Action Text sees them.
+2. **Render**: `Post#rendered_content` decodes and returns `html_safe` HTML; views must use `rendered_content`, not `content`, for display.
+3. **Edit**: `app/javascript/init.js` decodes for TinyMCE reload (and re-encodes legacy raw HTML).
+4. Legacy `⟦ERB_*⟧` placeholder posts are still decoded as a fallback.
+
+`config/initializers/action_text.rb` extends the sanitizer allow-list (tables, svg, `data-turbo`). The decode regex is looser than the encode one, so a block that was never encoded can still match it; a failed `strict_decode64` leaves the block untouched instead of raising, which used to 500 the post for every visitor.
+
+### Image serving (two paths)
+
+1. **Cover images**: Active Storage `cover_image` with named WebP variants (`:thumbnail`…`:hero`) defined on `Post`; rendered through `ImageHelper` (`optimized_image_tag`, `responsive_image_tag`). Only the LCP image should get `fetchpriority: high`/`lazy: false`.
+2. **In-post images**: TinyMCE uploads to `UploadsController` (type/size validation), which returns a JSON `srcset` of Active Storage variant URLs.
+
+`config.active_storage.resolve_model_to_route = :rails_storage_proxy` in `config/application.rb` is what makes either path CDN-cacheable — the default redirect mode emits `max-age=300, private` behind a 302, which Cloudflare cannot cache. Build URLs with `url_for`/`polymorphic_path` so they follow that setting; `rails_blob_url` and `rails_blob_representation_url` are pinned to the redirect routes and silently ignore it.
+
+`ImageHelper#intrinsic_dimensions` derives `width`/`height` from the blob's analyzed size rather than hardcoding them. Those attributes drive an `aspect-ratio` that keeps governing the box after load, so a wrong pair stretches the image wherever no `object-fit` hides it. When the analysis job has not run yet the attributes are omitted rather than guessed.
+
+A third path used to exist — `ThumbnailsController` resizing `app/assets/images/thumbnail/` on demand — and was removed: no view ever linked to it, and an unvalidated `width` let anyone evict the whole cache.
+
+### Frontend
+
+Importmap ESM only. Stimulus controllers live in `app/javascript/controllers/`; `app/javascript/init.js` is a separate non-Stimulus module handling TinyMCE, PrismJS, and MathJax initialization with Turbo lifecycle events — third-party widget integration usually belongs there. Trix and Action Text's JS are deliberately not pinned: the editor is a TinyMCE-backed `text_area`, so they were dead weight that importmap still preloaded.
+
+Prism, Mermaid and MathJax are loaded per page, not globally. A view declares what it needs via `ApplicationHelper#require_content_libraries` — `posts#show` derives it from the body with `content_libraries_for`, the editor form declares `:prism` because TinyMCE's codesample plugin reads the global `Prism` — and the layout gates each script block on `content_library?`. Because the gated scripts only exist on pages that need them, a Turbo Drive visit would arrive before they execute; every post link therefore carries `data: { turbo: false }`.
+
+Fonts are subset to the Latin ranges the site uses. `script/subset_fonts.py` reproduces it and enforces the safety property that makes it reviewable: every codepoint appearing in views, CSS, JS, locales or the posts table that the original font supported must survive.
+
+### Security configuration
+
+- CSP in `config/initializers/content_security_policy.rb` is **report-only** (`unsafe_inline`/`unsafe_eval` currently required by TinyMCE/GA/MathJax).
+- Production-only headers in `config/initializers/security_headers.rb`; Cloudflare IP ranges as trusted proxies in `config/initializers/cloudflare.rb` (real client IP for the brute-force logic).
+- Suppression files: `config/brakeman.ignore` (currently empty), `config/bundler-audit.yml` — check these before "fixing" a scanner finding.
+
+### Other conventions
+
+- Error pages are dynamic: `config.exceptions_app = routes` → `ErrorsController` (`/404`, `/422`, `/500`).
+- `posts#index` conditionally renders the `show_all` template (when `page` or `category` params are present); `search`/`tag`/`archive` also render `show_all`. Listing pages must use `listing_scope` (eager-loads tags and cover image) to avoid N+1.
+- `Post#read_time` reads the denormalized `posts.word_count`, filled by a `before_save`. It must not touch `content` — parsing the Action Text body per card is exactly the cost the column removes, and it is why `listing_scope` no longer eager-loads rich text. Action Text bodies are not a `posts` column, so the record is not dirty when only the body changes; `before_save` still runs, which is what keeps the count in sync.
+- Test fixtures include an admin (`admins(:one)`, password `"password"`); use the `sign_in_as_admin` helper in `test_helper.rb` for admin-only actions.
+- Test env uses `:memory_store`, not `:null_store`, so login throttling is testable at all — and `test_helper.rb` clears the cache before each test, since every request comes from 127.0.0.1 and would otherwise inherit the previous test's attempts.
+- Deployment: `kamal deploy` with `config/deploy.yml`; secrets flow from `.kamal/secrets` (`RAILS_MASTER_KEY`, `ADMIN_*`, `SUPABASE_DB_PASSWORD`).


### PR DESCRIPTION
Understand-Anything 지식 그래프를 저장소에 포함시키고, 그동안 미추적 상태였던 `CLAUDE.md` 를 현재 코드에 맞게 고쳐 함께 커밋합니다.

## `.ua/` 커밋 범위

[Understand-Anything 한국어 README](https://github.com/Egonex-AI/Understand-Anything/blob/main/READMEs/README.ko-KR.md) 의 안내를 따랐습니다.

> 커밋할 대상: `.ua/` 내부의 모든 파일. 단, `intermediate/` 와 `diff-overlay.json` 은 제외합니다
>
> 그래프는 단지 JSON 파일입니다 — 한 번만 커밋하면 팀원은 파이프라인을 건너뛸 수 있습니다

`.gitignore` 에 `/.ua/intermediate/` 와 `/.ua/diff-overlay.json` 을 넣고, 문서에는 없지만 `/.ua/.trash-*/` 도 추가했습니다. 스킬이 실행할 때마다 만드는 임시 디렉터리로 현재 101개 파일 2.5MB 가 쌓여 있고, 7일 후 스킬이 스스로 정리합니다.

들어가는 것은 5개 파일 **334KB** 입니다 — 문서가 git-lfs 를 권하는 10MB 기준에 한참 못 미칩니다.

| 파일 | 크기 |
|---|---|
| `knowledge-graph.json` | 256KB |
| `fingerprints.json` | 77KB |
| `.understandignore` | 2KB |
| `config.json` · `meta.json` | 1KB 미만 |

## CLAUDE.md 최신화

민감정보는 없습니다 — 환경변수 *이름* 과 이미 `test/fixtures/admins.yml` 에 있는 테스트 비밀번호뿐입니다.

다만 최근 세 PR(#136 · #137 · #138)을 반영하지 않아 **존재하지 않는 코드를 찾아가게 만드는** 서술이 남아 있었습니다.

| 낡은 서술 | 실제 |
|---|---|
| 세션에 저장하는 brute-force 잠금 | 그게 버그였다 — 쿠키에 있어 우회 가능했고, 지금은 캐시 기반 IP 별 실패 카운터 |
| 이미지 서빙 3경로 | `ThumbnailsController` 삭제로 2경로 |
| `config/brakeman.ignore` 확인 안내 | 유일한 항목이 삭제된 컨트롤러 것이라 비어 있음 |
| `listing_scope` 가 rich text 를 eager-load | `posts.word_count` 로 대체돼 더 이상 적재하지 않음 |

여기에 **왜 그렇게 돼 있는지 모르면 무심코 되돌리기 쉬운** 것들을 추가했습니다.

- 손으로 적은 `CONDITIONAL_GET_CACHE_CONTROL` — `after_action` 이 `handle_conditional_get!` 보다 먼저 돌아 Rails 기본값이 막히기 때문
- `cache_version` 기반 index ETag — relation 의 `to_sql` 에 `Time.current` 가 마이크로초까지 박히기 때문
- `tag_list=` 의 `touch` — HABTM 할당이 레코드를 dirty 로 만들지 않기 때문
- `polymorphic_path` 기반 URL 생성 — `rails_blob_url` 은 redirect 라우트에 고정돼 `resolve_model_to_route` 를 무시함
- Prism/Mermaid/MathJax 조건부 로딩과 그것이 요구하는 `data: { turbo: false }`
- 테스트 환경의 `:memory_store` 와 매 테스트 캐시 초기화

`ThumbnailsController` 는 삭제 이유를 한 줄로 남겨, 나중에 같은 엔드포인트를 다시 만들지 않도록 했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kamillee0918/blog-with-rails/pull/139" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->