### PR TITLE
fix: pin the prev/next card thumbnail to a fixed square

### DIFF
--- a/app/assets/stylesheets/site.css
+++ b/app/assets/stylesheets/site.css
@@ -3307,9 +3307,23 @@ body {
   margin: 10px 0
 }
 
+/* 썸네일 박스는 못 박고, 원본 비율은 object-fit 이 흡수한다.
+   responsive_image_tag 가 붙이는 width/height 속성은 원본 비율 그대로라
+   브라우저에서 aspect-ratio 로 남는다. 예전처럼 너비만 제한하면 그 비율이
+   높이를 결정해서, 16:9 배너는 납작하고 세로로 긴 그림은 카드 높이(170px)를
+   넘겨 잘렸다. 분석 전이라 width/height 가 아예 없는 표지도 있어 편차가 더 컸다. */
+.ts-post-unfurl-img {
+  flex: 0 0 auto;
+  align-self: center;
+  padding-right: 12px
+}
+
 .ts-post-unfurl-img img {
-  max-width: 150px;
-  contain-intrinsic-size: revert
+  display: block;
+  width: 130px;
+  height: 130px;
+  object-fit: cover;
+  border-radius: 8px
 }
 
 .ts-post-unfurl-date {

--- a/app/views/posts/_post_card.html.erb
+++ b/app/views/posts/_post_card.html.erb
@@ -17,7 +17,7 @@
           alt: post.title,
           lazy: lazy_image,
           fetchpriority: false,
-          sizes: "auto, (max-width: 160px) 100vw, 160px" %>
+          sizes: "130px" %>
     </div>
   <% end %>
 </div>


### PR DESCRIPTION
게시글 하단 이전/다음 카드의 썸네일 비율이 글마다 달라 보이는 문제를 고칩니다.

## 원인

`.ts-post-unfurl-img img`가 `max-width: 150px`로 **너비만** 잡고 있었습니다. 높이는 `responsive_image_tag`가 붙이는 `width`/`height` 속성에서 브라우저가 유도한 `aspect-ratio`가 결정하므로, 카드 높이가 원본 이미지 비율을 그대로 따라갔습니다.

- `atcoder.png`(1024×572) → 150×84로 납작하게 렌더링, 카드 아래쪽이 빔
- 세로로 긴 그림 → 카드 높이(170px)를 넘겨 `overflow: hidden`에 잘림
- **분석 전이라 `width`/`height`가 아예 없는 표지** → 위 둘과 또 다른 세 번째 동작. 현재 프로덕션 표지 28장 중 11장이 여기 해당합니다

## 수정

박스를 130×130으로 못 박고 `object-fit: cover`가 원본 비율을 흡수하게 했습니다. 세 경우 모두 동일하게 렌더링되며 이미지가 늘어나지 않습니다.

`sizes` 속성도 함께 고쳤습니다. 실제 박스보다 큰 160px를 요청하고 있었고, 목록이 `auto`로 시작하는데 `auto`는 지연 로딩 이미지에서만 유효합니다 — 다음 글 카드는 `loading="eager"`입니다.

## 검증

브라우저에서 직접 확인했습니다. 원본이 130×99, 130×68로 서로 다른 두 카드가 모두 정확히 130×130으로 배치됩니다.

`rubocop` 통과(57 files, 0 offenses).

> 로컬 테스트에서 `UploadsControllerTest` 2건이 실패하지만 이 변경과 무관합니다. Windows 전용 픽스처 업로드 문제로, #140에서 이미 고쳤습니다. 이 브랜치는 main 기반이라 그 수정이 없을 뿐이고, Linux CI에서는 원래 통과합니다.

## 참고

`.ts-post-unfurl-thumb`(background-image 방식의 옛 썸네일 규칙)는 어느 뷰에서도 쓰이지 않는 죽은 CSS입니다. 이번 PR 범위 밖이라 두었습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kamillee0918/blog-with-rails/pull/141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->