### PR TITLE
fix: do not demand DB credentials while building the image

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,13 +10,25 @@
 #   SUPABASE_DB_PASSWORD — Supabase 프로젝트 DB 비밀번호 (secrets)
 #   SUPABASE_DB_PORT     — 6543 (transaction pooler)
 #
-# HOST/USER 에 기본값을 두지 않는다. 예전에는 폐기된 프로젝트를 가리키는 폴백이
-# 있었고, 환경변수가 하나라도 비면 존재하지 않는 곳으로 조용히 접속을 시도했다.
-# 지금은 누락된 키 이름을 대며 부팅이 실패한다.
-#
-# 다만 필수로 취급하는 건 production 일 때뿐이다. rake 의 load_database_yaml 은
-# 현재 환경과 무관하게 이 파일 전체를 ERB 로 평가하므로, 무조건 fetch 하면
-# SQLite 만 쓰는 개발·테스트에서도 db:test:prepare 가 KeyError 로 죽는다.
+# HOST/USER 에 기본값은 두지 않는다. 자세한 이유는 아래 ERB 주석 참고.
+
+<%
+  # 자격증명이 "반드시" 있어야 하는 시점인지 판단한다.
+  #
+  # 이 파일은 두 가지 이유로 production 이 아닐 때도 통째로 평가된다.
+  #   - rake 의 load_database_yaml 은 현재 환경과 무관하게 파일 전체를 읽는다
+  #     (그래서 SQLite 만 쓰는 db:test:prepare 도 아래 production 블록을 평가한다)
+  #   - Dockerfile 은 RAILS_ENV=production 을 박아 둔 채 이미지 빌드 중에
+  #     assets:precompile 을 돌린다. 그 시점에 DB 자격증명은 존재하지 않는다.
+  #
+  # 후자를 Rails 는 SECRET_KEY_BASE_DUMMY 로 알려 준다 — "실행이 아니라 빌드"라는 신호다.
+  building_image = !ENV["SECRET_KEY_BASE_DUMMY"].to_s.empty?
+  credentials_required = Rails.env.production? && !building_image
+
+  # 실제로 접속할 때만 누락을 실패로 취급한다. 예전에는 폐기된 프로젝트를 가리키는
+  # 폴백이 있어서, 환경변수가 비면 존재하지 않는 곳으로 조용히 접속을 시도했다.
+  db_env = ->(key) { credentials_required ? ENV.fetch(key) : ENV[key] }
+%>
 
 # === SQLite (Development / Test / Solid adapters) ===
 sqlite: &sqlite
@@ -39,10 +51,10 @@ production:
     adapter: postgresql
     encoding: unicode
     pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-    host: <%= Rails.env.production? ? ENV.fetch("SUPABASE_DB_HOST") : ENV["SUPABASE_DB_HOST"] %>
+    host: <%= db_env.call("SUPABASE_DB_HOST") %>
     port: <%= ENV.fetch("SUPABASE_DB_PORT", 6543) %>
     database: postgres
-    username: <%= Rails.env.production? ? ENV.fetch("SUPABASE_DB_USER") : ENV["SUPABASE_DB_USER"] %>
+    username: <%= db_env.call("SUPABASE_DB_USER") %>
     password: <%= ENV["SUPABASE_DB_PASSWORD"] %>
     prepared_statements: false
     sslmode: require


### PR DESCRIPTION
`fly deploy`가 `assets:precompile` 단계에서 실패한 것을 고칩니다. **#140에서 제가 넣은 회귀입니다.**

## 원인

`Dockerfile:24`가 빌드 스테이지 전체에 `RAILS_ENV="production"`을 박아 두고, `:54`에서 `assets:precompile`을 돌립니다. 그래서 `Rails.env.production?`만으로 필수 여부를 판단하면, **DB 자격증명이 없고 필요하지도 않은 이미지 빌드 중에** `KeyError`가 납니다.

```
=> ERROR [build 6/6] RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
KeyError: key not found: "SUPABASE_DB_HOST"
/rails/config/database.yml:42:in 'fetch'
```

## 수정

Rails가 이 상태를 이미 알려 줍니다 — `SECRET_KEY_BASE_DUMMY`는 "실행이 아니라 빌드"라는 신호로 존재합니다. 이 값으로 구분하면 지킬 가치가 있는 성질은 그대로 남습니다:

- **실제 프로덕션 부팅**에서 변수가 비면 누락된 키 이름을 대며 실패 (폐기된 프로젝트로 조용히 접속하던 예전 동작 방지)
- **빌드**와 SQLite만 쓰는 개발·테스트는 같은 줄을 무해하게 평가

## 검증 — 이번엔 5경로 전부

지난번에 빠뜨린 빌드 타임 경로를 포함해, 실제로 실행해 확인했습니다.

| 경로 | 결과 |
|---|---|
| `RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 assets:precompile` *(실패했던 그 명령)* | **exit 0** |
| `RAILS_ENV=test db:test:prepare` | exit 0 |
| 개발 부팅 | ok |
| production · 변수 없음 · DUMMY 없음 | `KeyError: key not found: "SUPABASE_DB_HOST"` |
| production · 변수 있음 | host 정상 해석 |

로컬 게이트: 테스트 **86 runs / 197 assertions / 0 failures**, Brakeman 0건, RuboCop 0건.

## 회고

#140에서 `bin/rails runner`(개발)와 CI(`db:test:prepare`)만 확인하고 "안전하다"고 판단했습니다. 세 번째 경로인 **이미지 빌드**는 두 곳 어디서도 실행되지 않아 드러나지 않았고, `fly deploy`에서야 나타났습니다. 이번엔 실패한 명령 자체를 로컬에서 그대로 재현해 확인했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kamillee0918/blog-with-rails/pull/142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->