### PR TITLE
feat: add a content audit for what the code gates cannot see

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ bin/rails test test/models/post_test.rb:42        # single test by line
 # Quality gates
 bin/check-code           # pre-push gate: Brakeman → RuboCop → all tests
 bin/ci                   # full local CI (adds bundler-audit, importmap audit, seed replant)
+bin/rails content:check  # content audit (see below) — SEVERITY=error to skip warnings
 bin/rubocop -a           # style (rubocop-rails-omakase) with autocorrect
 bin/brakeman --no-pager  # security static analysis (suppressions: config/brakeman.ignore)
 ```
@@ -87,6 +88,15 @@ Importmap ESM only. Stimulus controllers live in `app/javascript/controllers/`; 
 Prism, Mermaid and MathJax are loaded per page, not globally. A view declares what it needs via `ApplicationHelper#require_content_libraries` — `posts#show` derives it from the body with `content_libraries_for`, the editor form declares `:prism` because TinyMCE's codesample plugin reads the global `Prism` — and the layout gates each script block on `content_library?`. Because the gated scripts only exist on pages that need them, a Turbo Drive visit would arrive before they execute; every post link therefore carries `data: { turbo: false }`.
 
 Fonts are subset to the Latin ranges the site uses. `script/subset_fonts.py` reproduces it and enforces the safety property that makes it reviewable: every codepoint appearing in views, CSS, JS, locales or the posts table that the original font supported must survive.
+
+### Content auditing
+
+`ContentAudit` (`app/models/content_audit.rb`, exposed as `bin/rails content:check`) checks what the code gates cannot: broken internal links, missing/placeholder `alt`, short summaries, untagged posts, unanalysed or oversized covers, and in-post images still on the `redirect` route. It is **data**, not code — running it against the dev database says nothing about the live site, so point it at production (`fly ssh console -C "bin/rails content:check"`). Errors set a non-zero exit; warnings do not, because they are judgement calls.
+
+Two traps it deliberately avoids, both of which produced false positives during the audit that motivated it:
+
+- The malformed-link check strips the query string before looking for whitespace. `+` means space in a query but is a literal character in a path, so decoding the whole URL flags `?q=build+tools` as broken.
+- A `/posts/` path only counts as internal when the link is relative or its host matches `APP_HOST`; other sites have `/posts/` too.
 
 ### Security configuration
 

--- a/app/models/content_audit.rb
+++ b/app/models/content_audit.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+# 발행 전 콘텐츠 점검.
+#
+# 코드 품질 게이트(Brakeman/RuboCop/테스트)가 잡지 못하는 것들 — 본문 안에서만
+# 드러나는 문제들 — 을 본다. 정적 분석 대상이 아니라 DB 에 들어 있는 데이터이므로,
+# 실제 콘텐츠가 있는 곳을 향해 돌려야 의미가 있다. `rake content:check` 참고.
+#
+# 로직을 rake task 안이 아니라 여기 두는 이유는 테스트를 붙이기 위해서다.
+class ContentAudit
+  Finding = Struct.new(:post_id, :title, :check, :severity, :detail, keyword_init: true)
+
+  # 검색 결과 스니펫과 카드 UI 가 쓰기에 부족하지 않을 최소치.
+  SUMMARY_MIN_LENGTH = 50
+  # 시리즈 접두사가 길어지면 실제 주제가 목록에서 잘려 나간다.
+  TITLE_MAX_LENGTH = 40
+  # 표지는 변환 전 원본이 이 이상이면 variant 생성 비용이 커진다.
+  COVER_MAX_BYTES = 500.kilobytes
+  # 스크린리더가 그대로 읽어 버려 빈 alt 보다 오히려 나쁜 값들.
+  PLACEHOLDER_ALT = /\A(uploaded image|image|img|untitled)\z/i
+
+  def self.run(scope = Post.all) = new(scope).run
+
+  def initialize(scope = Post.all)
+    @scope = scope
+  end
+
+  def run
+    @findings = []
+    @slugs = Post.pluck(:slug).compact_blank.to_set
+    @ids = Post.pluck(:id).map(&:to_s).to_set
+
+    @scope.includes(:tags, :rich_text_content, cover_image_attachment: :blob).find_each do |post|
+      body = post.content&.body_before_type_cast.to_s
+
+      check_summary(post)
+      check_title(post)
+      check_tags(post)
+      check_cover(post)
+      check_images(post, body)
+      check_internal_links(post, body)
+    end
+
+    @findings
+  end
+
+  private
+
+  def add(post, check, severity, detail)
+    @findings << Finding.new(post_id: post.id, title: post.title.to_s, check: check,
+                             severity: severity, detail: detail)
+  end
+
+  def check_summary(post)
+    length = post.summary.to_s.strip.length
+    return if length >= SUMMARY_MIN_LENGTH
+
+    add(post, :summary_too_short, :warning,
+        length.zero? ? "요약 없음" : "요약 #{length}자 (최소 #{SUMMARY_MIN_LENGTH}자)")
+  end
+
+  def check_title(post)
+    length = post.title.to_s.length
+    return if length <= TITLE_MAX_LENGTH
+
+    add(post, :title_too_long, :warning, "제목 #{length}자 (권장 #{TITLE_MAX_LENGTH}자 이하)")
+  end
+
+  def check_tags(post)
+    add(post, :no_tags, :warning, "태그 없음") if post.tags.empty?
+  end
+
+  def check_cover(post)
+    unless post.cover_image.attached?
+      add(post, :cover_missing, :warning, "표지 이미지 없음")
+      return
+    end
+
+    blob = post.cover_image.blob
+    # 분석 전이면 ImageHelper 가 width/height 를 생략하고, 그러면 aspect-ratio 가
+    # 잡히지 않아 카드와 히어로에서 레이아웃 시프트가 난다.
+    add(post, :cover_unanalyzed, :error, "표지 미분석 (#{blob.filename})") unless blob.analyzed?
+
+    return unless blob.byte_size > COVER_MAX_BYTES
+
+    add(post, :cover_too_large, :warning,
+        "표지 #{(blob.byte_size / 1024.0).round}KB (권장 #{COVER_MAX_BYTES / 1024}KB 이하) — #{blob.filename}")
+  end
+
+  def check_images(post, body)
+    body.scan(/<img\b[^>]*>/i).each do |tag|
+      alt = tag[/\salt\s*=\s*"([^"]*)"/i, 1]
+      if alt.nil?
+        add(post, :image_alt_missing, :error, "alt 속성 없음 — #{src_name(tag)}")
+      elsif alt.strip.empty?
+        add(post, :image_alt_missing, :error, "alt 가 비어 있음 — #{src_name(tag)}")
+      elsif alt.strip.match?(PLACEHOLDER_ALT)
+        add(post, :image_alt_placeholder, :error, %(alt="#{alt}" 는 자리표시자 — #{src_name(tag)}))
+      end
+    end
+
+    # redirect 라우트는 302 뒤에 max-age=300, private 을 붙여 Cloudflare 가 캐시하지
+    # 못한다. 본문 이미지도 표지와 같이 proxy 경로로 나가야 한다.
+    count = body.scan(%r{/rails/active_storage/(?:blobs|representations)/redirect/}).size
+    add(post, :image_redirect_route, :error, "CDN 이 캐시할 수 없는 redirect 경로 #{count}개") if count.positive?
+  end
+
+  def check_internal_links(post, body)
+    body.scan(/href="([^"]*)"/i).flatten.each do |href|
+      path = percent_decode(href.split(/[?#]/).first.to_s)
+
+      # 링크 필드에 설명문이 통째로 들어간 오조작. 경로에 섞인 공백이 신호다.
+      # 쿼리스트링은 떼어 내고 본다 — `?q=build+tools` 처럼 `+` 가 공백을 뜻하는
+      # 정상 URL 을 깨진 링크로 오해하지 않기 위해서다.
+      if path.match?(/\s/)
+        add(post, :malformed_link, :error, path.truncate(80))
+        next
+      end
+
+      next unless internal_post_link?(href)
+
+      key = path.split("/posts/").last.to_s
+      next if key.empty? || @slugs.include?(key) || @ids.include?(key)
+
+      add(post, :broken_internal_link, :error, path.truncate(80))
+    end
+  end
+
+  # 남의 사이트에도 /posts/ 는 있다. 상대 경로이거나 우리 호스트일 때만 본다.
+  def internal_post_link?(href)
+    return true if href.start_with?("/posts/")
+    return false unless href.include?("/posts/")
+
+    host = URI.parse(href).host
+    host.present? && host.delete_prefix("www.") == app_host
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def app_host
+    @app_host ||= ENV.fetch("APP_HOST", "kamillee0918.blog").delete_prefix("www.")
+  end
+
+  def src_name(tag)
+    tag[/src="[^"]*\/([^\/"?]+)"/i, 1] || "(src 불명)"
+  end
+
+  # %XX 만 푼다. CGI.unescape 는 `+` 도 공백으로 바꾸는데, 경로에서 `+` 는 공백이
+  # 아니라 그냥 문자다. 그걸 공백으로 되돌리면 멀쩡한 링크가 깨진 것처럼 보인다.
+  def percent_decode(str)
+    str.gsub(/%([0-9A-Fa-f]{2})/) { [ Regexp.last_match(1) ].pack("H*") }
+       .force_encoding(Encoding::UTF_8)
+       .scrub
+  end
+end

--- a/lib/tasks/content.rake
+++ b/lib/tasks/content.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+namespace :content do
+  desc "발행 전 콘텐츠 점검 (본문 링크·alt·요약·태그·표지). SEVERITY=error 로 error 만 볼 수 있다"
+  task check: :environment do
+    findings = ContentAudit.run
+    findings.select! { |f| f.severity == :error } if ENV["SEVERITY"] == "error"
+
+    if findings.empty?
+      puts "콘텐츠 점검 통과 — 지적 사항 없음 (글 #{Post.count}건)"
+      next
+    end
+
+    errors = findings.count { |f| f.severity == :error }
+    warnings = findings.size - errors
+
+    findings.group_by(&:check).sort_by { |_, list| -list.size }.each do |check, list|
+      severity = list.first.severity == :error ? "오류" : "경고"
+      puts "\n[#{severity}] #{check} — #{list.size}건"
+      list.sort_by(&:post_id).each do |f|
+        puts "  ##{f.post_id} #{f.title.to_s.truncate(38).ljust(38)} #{f.detail}"
+      end
+    end
+
+    puts "\n합계: 오류 #{errors}건 / 경고 #{warnings}건 (글 #{Post.count}건)"
+
+    # 오류가 있으면 실패로 끝낸다. 경고는 판단 대상이라 종료 코드를 바꾸지 않는다.
+    abort("\n오류가 남아 있습니다.") if errors.positive?
+  end
+end

--- a/test/models/content_audit_test.rb
+++ b/test/models/content_audit_test.rb
@@ -1,0 +1,176 @@
+require "test_helper"
+
+class ContentAuditTest < ActiveSupport::TestCase
+  # 개별 검사를 격리해서 보려고, 만든 글 하나만 감사한다.
+  def audit(post)
+    ContentAudit.run(Post.where(id: post.id))
+  end
+
+  def checks_for(post)
+    audit(post).map(&:check)
+  end
+
+  def create_post(**attrs)
+    Post.create!({ title: "Some Post", category: "Test", published_at: 1.day.ago,
+                   summary: "이 글은 요약 길이 검사를 통과할 만큼 충분히 긴 설명을 담고 있으며, " \
+                            "검색 결과 스니펫과 카드 UI 에서도 정보량이 부족하지 않습니다." }.merge(attrs))
+  end
+
+  test "깨끗한 글에서는 본문 관련 지적이 나오지 않는다" do
+    post = create_post(content: '<p>본문</p><img src="/x.png" alt="설명이 있는 이미지">')
+    post.tag_list = "ruby"
+
+    found = checks_for(post)
+    assert_not_includes found, :image_alt_missing
+    assert_not_includes found, :broken_internal_link
+    assert_not_includes found, :summary_too_short
+    assert_not_includes found, :no_tags
+  end
+
+  # === 내부 링크 ===
+
+  test "존재하지 않는 slug 로 가는 내부 링크를 잡는다" do
+    post = create_post(title: "Linker", content: '<a href="/posts/nope-not-here">x</a>')
+
+    assert_includes checks_for(post), :broken_internal_link
+  end
+
+  test "존재하는 slug 로 가는 내부 링크는 통과한다" do
+    create_post(title: "Target Post")
+    post = create_post(title: "Linker Two", content: '<a href="/posts/target-post">x</a>')
+
+    assert_not_includes checks_for(post), :broken_internal_link
+  end
+
+  test "slug 가 없는 글은 id 로 링크해도 통과한다" do
+    target = create_post(title: "한국어 제목")
+    assert_nil target.slug
+    post = create_post(title: "Linker Three", content: %(<a href="/posts/#{target.id}">x</a>))
+
+    assert_not_includes checks_for(post), :broken_internal_link
+  end
+
+  test "절대 URL 로 쓴 내부 링크도 검사한다" do
+    post = create_post(title: "Linker Four",
+                       content: '<a href="https://kamillee0918.blog/posts/nope-not-here">x</a>')
+
+    assert_includes checks_for(post), :broken_internal_link
+  end
+
+  test "남의 사이트의 /posts/ 링크는 건드리지 않는다" do
+    post = create_post(title: "Linker Five",
+                       content: '<a href="https://example.com/posts/whatever">x</a>')
+
+    assert_not_includes checks_for(post), :broken_internal_link
+  end
+
+  test "URL 필드에 설명문이 들어간 오조작을 잡는다" do
+    post = create_post(title: "Broken Href",
+                       content: '<a href="https://kamillee0918.blog/코드%20및%20모델:%20MIT%20License">LICENSE</a>')
+
+    assert_includes checks_for(post), :malformed_link
+  end
+
+  # 쿼리스트링의 `+` 는 공백을 뜻하지만 경로의 `+` 는 그냥 문자다. 이걸 구분하지
+  # 않고 CGI.unescape 로 통째로 풀면 멀쩡한 링크가 깨진 것으로 보고된다.
+  test "쿼리스트링에 + 가 있는 정상 링크를 오탐하지 않는다" do
+    post = create_post(title: "Plus Query",
+                       content: '<a href="https://visualstudio.microsoft.com/downloads/?q=build+tools#x">VS</a>')
+
+    assert_not_includes checks_for(post), :malformed_link
+    assert_not_includes checks_for(post), :broken_internal_link
+  end
+
+  # === 이미지 ===
+
+  test "alt 가 없거나 비었으면 잡는다" do
+    no_alt = create_post(title: "No Alt", content: '<img src="/a.png">')
+    empty = create_post(title: "Empty Alt", content: '<img src="/b.png" alt="">')
+
+    assert_includes checks_for(no_alt), :image_alt_missing
+    assert_includes checks_for(empty), :image_alt_missing
+  end
+
+  test "자리표시자 alt 를 따로 구분해 잡는다" do
+    post = create_post(title: "Placeholder Alt", content: '<img src="/c.png" alt="Uploaded image">')
+
+    assert_includes checks_for(post), :image_alt_placeholder
+  end
+
+  test "CDN 이 캐시할 수 없는 redirect 경로를 잡는다" do
+    post = create_post(
+      title: "Redirect Route",
+      content: '<img src="/rails/active_storage/blobs/redirect/abc/x.png" alt="설명">'
+    )
+
+    assert_includes checks_for(post), :image_redirect_route
+  end
+
+  test "proxy 경로는 통과한다" do
+    post = create_post(
+      title: "Proxy Route",
+      content: '<img src="/rails/active_storage/blobs/proxy/abc/x.png" alt="설명">'
+    )
+
+    assert_not_includes checks_for(post), :image_redirect_route
+  end
+
+  # === 메타데이터 ===
+
+  test "짧은 요약을 잡는다" do
+    post = create_post(title: "Short Summary", summary: "너무 짧음")
+
+    assert_includes checks_for(post), :summary_too_short
+  end
+
+  test "긴 제목을 잡는다" do
+    post = create_post(title: "가" * (ContentAudit::TITLE_MAX_LENGTH + 1))
+
+    assert_includes checks_for(post), :title_too_long
+  end
+
+  test "태그 없는 글을 잡는다" do
+    post = create_post(title: "No Tags Here")
+
+    assert_includes checks_for(post), :no_tags
+  end
+
+  test "표지 없는 글을 잡는다" do
+    post = create_post(title: "No Cover")
+
+    assert_includes checks_for(post), :cover_missing
+  end
+
+  # 분석 전이면 ImageHelper 가 width/height 를 생략하고, 그러면 aspect-ratio 가
+  # 잡히지 않아 레이아웃 시프트가 난다. 표지 28장이 전부 이 상태였던 적이 있다.
+  test "미분석 표지를 잡는다" do
+    post = create_post(title: "Unanalyzed Cover")
+    post.cover_image.attach(io: file_fixture("test_image.png").open,
+                            filename: "test_image.png", content_type: "image/png")
+
+    assert_includes checks_for(post), :cover_unanalyzed
+  end
+
+  test "분석된 표지는 통과한다" do
+    post = create_post(title: "Analyzed Cover")
+    post.cover_image.attach(io: file_fixture("test_image.png").open,
+                            filename: "test_image.png", content_type: "image/png")
+    post.cover_image.blob.analyze
+
+    assert_not_includes checks_for(post), :cover_unanalyzed
+  end
+
+  test "심각도가 error 와 warning 으로 나뉜다" do
+    post = create_post(title: "Mixed", summary: "짧음", content: '<img src="/a.png">')
+
+    findings = audit(post)
+    assert_includes findings.select { |f| f.severity == :error }.map(&:check), :image_alt_missing
+    assert_includes findings.select { |f| f.severity == :warning }.map(&:check), :summary_too_short
+  end
+
+  test "기본 스코프는 전체 글이다" do
+    create_post(title: "Scan Me", content: '<img src="/a.png">')
+
+    assert_includes ContentAudit.run.map(&:check), :image_alt_missing
+  end
+end


### PR DESCRIPTION
3단계(P2)의 첫 항목입니다. `BLOG_CONTENT_REVIEW.md` §7.6의 "발행 전 점검 rake task"와 §7.5의 "내부 링크 무결성 점검"을 하나로 구현했습니다.

## 왜 필요한가

Brakeman·RuboCop·테스트는 **코드**를 봅니다. 그런데 최근 독자에게 실제로 도달한 문제들은 전부 `posts` 테이블 안에 있었습니다.

- slug 규칙이 바뀐 뒤 갱신되지 않은 내부 링크 (간판 시리즈의 편 간 이동이 깨져 있었음)
- 본문 이미지 27장의 alt가 **전부** 비어 있거나 `"Uploaded image"` 자리표시자
- 이미지 URL 21개가 Cloudflare가 캐시할 수 없는 redirect 경로
- 표지 28장이 미분석이라 `ImageHelper`가 `width`/`height`를 생략 → 전 페이지 레이아웃 시프트

전부 일회성 스크립트로 찾아냈습니다. 이 PR은 그 검사를 **반복 가능하고 테스트 가능한 형태**로 만듭니다.

## 구성

| 파일 | 역할 |
|---|---|
| `app/models/content_audit.rb` | 검사 로직. rake task 안이 아니라 클래스로 둔 이유는 테스트를 붙이기 위해서 |
| `lib/tasks/content.rake` | `bin/rails content:check` |
| `test/models/content_audit_test.rb` | 20개 테스트 |

검사 항목: 깨진 내부 링크 · URL 오조작 · alt 누락/자리표시자 · redirect 경로 · 요약 길이 · 제목 길이 · 태그 없음 · 표지 없음/미분석/용량 초과.

**오류는 종료 코드를 1로 만들고, 경고는 그러지 않습니다.** 요약 길이나 표지 용량은 결함이 아니라 판단 대상이기 때문입니다.

## 대상은 코드가 아니라 데이터입니다

개발 DB를 향해 돌려 봐야 실제 사이트에 대해 아무것도 말해 주지 않습니다. 프로덕션을 향해 돌려야 합니다:

```bash
fly ssh console -C "bin/rails content:check"
```

이 이유로 `bin/check-code`에는 붙이지 않았습니다. CI는 빈 테스트 DB를 보므로 항상 통과해 오히려 오해를 만듭니다.

## 수동 감사에서 겪은 오탐 2건을 테스트로 고정

도구가 같은 실수를 물려받지 않도록 회귀 테스트로 박아 두었습니다.

1. **URL의 공백을 볼 때 쿼리스트링을 먼저 떼어 냅니다.** `+`는 쿼리에서는 공백이지만 경로에서는 그냥 문자입니다. `CGI.unescape`로 통째로 풀면 `?q=build+tools`가 깨진 링크로 보고됩니다 — 실제로 제가 이 오탐으로 멀쩡한 링크를 "고칠 뻔"했습니다.
2. **`/posts/`가 있다고 다 내부 링크가 아닙니다.** 상대 경로이거나 호스트가 `APP_HOST`일 때만 검사합니다.

## 검증

로컬: 테스트 **106 runs / 250 assertions / 0 failures** (기존 86 → 106), Brakeman 0건, RuboCop 61 files 0건.

프로덕션 실행 결과가 **별도로 측정했던 수치와 정확히 일치**합니다:

| 검사 | 도구 | 별도 측정 |
|---|---|---|
| 요약 50자 미만 | 14건 | 14건 |
| 제목 40자 초과 | 3건 | 3건 |
| 태그 없음 | 2건 | 2건 |
| 표지 500KB 초과 | 28건 | 전부 PNG 평균 1.7MB |
| **오류** | **0건** | 링크·alt·redirect·미분석 전부 해소됨 |

즉 **2단계에서 고친 것들이 오류 0건으로 확인**되고, 남은 47건은 전부 경고(판단 대상)입니다.

## 다음

남은 P2 데이터 정리 — 태그 55개 중 1회 이하 42개, `cache`/`caching` 병합, `いもす法` 표기 통일, 요약 14건 보강, 태그 없는 글 2건. 이 도구가 그 진척을 측정합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)