### PR TITLE
fix: judge covers by width instead of file size

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,12 +91,13 @@ Fonts are subset to the Latin ranges the site uses. `script/subset_fonts.py` rep
 
 ### Content auditing
 
-`ContentAudit` (`app/models/content_audit.rb`, exposed as `bin/rails content:check`) checks what the code gates cannot: broken internal links, missing/placeholder `alt`, short summaries, untagged posts, unanalysed or oversized covers, and in-post images still on the `redirect` route. It is **data**, not code — running it against the dev database says nothing about the live site, so point it at production (`fly ssh console -C "bin/rails content:check"`). Errors set a non-zero exit; warnings do not, because they are judgement calls.
+`ContentAudit` (`app/models/content_audit.rb`, exposed as `bin/rails content:check`) checks what the code gates cannot: broken internal links, missing/placeholder `alt`, short summaries, untagged posts, unanalysed or badly sized covers, and in-post images still on the `redirect` route. It is **data**, not code — running it against the dev database says nothing about the live site, so point it at production (`fly ssh console -C "bin/rails content:check"`). Errors set a non-zero exit; warnings do not, because they are judgement calls.
 
-Two traps it deliberately avoids, both of which produced false positives during the audit that motivated it:
+Three traps it deliberately avoids, all of which produced false positives or noise during the audits that motivated it:
 
 - The malformed-link check strips the query string before looking for whitespace. `+` means space in a query but is a literal character in a path, so decoding the whole URL flags `?q=build+tools` as broken.
 - A `/posts/` path only counts as internal when the link is relative or its host matches `APP_HOST`; other sites have `/posts/` too.
+- The cover check measures **width, not bytes** (`COVER_MIN_WIDTH`/`COVER_MAX_WIDTH`). Every view renders covers through `ImageHelper`, so the original is never served and its file size costs the reader nothing — a 500KB byte rule flagged all 28 covers and taught the reader to ignore the check. What does matter is the two ends of the srcset: wider than the largest entry (1920) is decoded and thrown away on every variant build, and narrower than the hero's display width (1024) renders soft, because `resize_to_limit` will not upscale. Dimensions are only known once the blob is analysed, so an unanalysed cover skips the size check rather than guessing.
 
 ### Security configuration
 

--- a/app/models/content_audit.rb
+++ b/app/models/content_audit.rb
@@ -14,8 +14,16 @@ class ContentAudit
   SUMMARY_MIN_LENGTH = 50
   # 시리즈 접두사가 길어지면 실제 주제가 목록에서 잘려 나간다.
   TITLE_MAX_LENGTH = 40
-  # 표지는 변환 전 원본이 이 이상이면 variant 생성 비용이 커진다.
-  COVER_MAX_BYTES = 500.kilobytes
+  # 표지 원본은 어떤 뷰에서도 그대로 나가지 않는다. 모든 렌더 경로가
+  # ImageHelper 를 거쳐 WebP variant 를 만들어 쓰므로, 원본에서 볼 것은
+  # 바이트 수가 아니라 그 variant 들을 감당할 수 있는 폭인지다.
+  #
+  # 위: responsive_image_tag 가 만드는 가장 큰 srcset 폭. 이보다 넓은 부분은
+  # 어떤 variant 로도 쓰이지 않으면서 variant 를 만들 때마다 디코딩 비용만 더한다.
+  COVER_MAX_WIDTH = 1920
+  # 아래: 상세 페이지 히어로의 표시 폭(sizes 속성 기준). resize_to_limit 은
+  # 확대하지 않으므로, 원본이 이보다 좁으면 LCP 이미지가 그대로 흐리게 나간다.
+  COVER_MIN_WIDTH = 1024
   # 스크린리더가 그대로 읽어 버려 빈 alt 보다 오히려 나쁜 값들.
   PLACEHOLDER_ALT = /\A(uploaded image|image|img|untitled)\z/i
 
@@ -79,12 +87,22 @@ class ContentAudit
     blob = post.cover_image.blob
     # 분석 전이면 ImageHelper 가 width/height 를 생략하고, 그러면 aspect-ratio 가
     # 잡히지 않아 카드와 히어로에서 레이아웃 시프트가 난다.
-    add(post, :cover_unanalyzed, :error, "표지 미분석 (#{blob.filename})") unless blob.analyzed?
+    unless blob.analyzed?
+      add(post, :cover_unanalyzed, :error, "표지 미분석 (#{blob.filename})")
+      # 분석 전에는 폭을 알 수 없다. 짐작하지 않고 치수 검사를 건너뛴다.
+      return
+    end
 
-    return unless blob.byte_size > COVER_MAX_BYTES
+    width = blob.metadata["width"].to_i
+    return unless width.positive?
 
-    add(post, :cover_too_large, :warning,
-        "표지 #{(blob.byte_size / 1024.0).round}KB (권장 #{COVER_MAX_BYTES / 1024}KB 이하) — #{blob.filename}")
+    if width > COVER_MAX_WIDTH
+      add(post, :cover_oversized, :warning,
+          "표지 폭 #{width}px — #{COVER_MAX_WIDTH}px 초과분은 variant 로 쓰이지 않는다 (#{blob.filename})")
+    elsif width < COVER_MIN_WIDTH
+      add(post, :cover_undersized, :warning,
+          "표지 폭 #{width}px — 히어로 표시 폭 #{COVER_MIN_WIDTH}px 보다 좁아 확대 없이 흐리게 나간다 (#{blob.filename})")
+    end
   end
 
   def check_images(post, body)

--- a/test/models/content_audit_test.rb
+++ b/test/models/content_audit_test.rb
@@ -10,6 +10,17 @@ class ContentAuditTest < ActiveSupport::TestCase
     audit(post).map(&:check)
   end
 
+  # 치수 검사를 보려면 분석된 blob 이 필요한데, 픽스처는 48x25 라 실제 분석으로는
+  # 원하는 폭을 만들 수 없다. 분석 결과만 원하는 값으로 바꿔 끼운다.
+  def attach_cover(post, width:, height:, byte_size: nil)
+    post.cover_image.attach(io: file_fixture("test_image.png").open,
+                            filename: "test_image.png", content_type: "image/png")
+    blob = post.cover_image.blob
+    blob.update!(metadata: blob.metadata.merge("width" => width, "height" => height, "analyzed" => true))
+    blob.update!(byte_size: byte_size) if byte_size
+    post.reload
+  end
+
   def create_post(**attrs)
     Post.create!({ title: "Some Post", category: "Test", published_at: 1.day.ago,
                    summary: "이 글은 요약 길이 검사를 통과할 만큼 충분히 긴 설명을 담고 있으며, " \
@@ -158,6 +169,41 @@ class ContentAuditTest < ActiveSupport::TestCase
     post.cover_image.blob.analyze
 
     assert_not_includes checks_for(post), :cover_unanalyzed
+  end
+
+  # 표지 원본은 어떤 뷰에서도 그대로 나가지 않는다 — 전부 WebP variant 를 거친다.
+  # 그래서 원본에서 볼 것은 파일 크기가 아니라 variant 들이 쓸 수 있는 폭이다.
+
+  test "가장 큰 srcset 폭보다 넓은 표지를 잡는다" do
+    post = create_post(title: "Oversized Cover")
+    attach_cover(post, width: ContentAudit::COVER_MAX_WIDTH + 1, height: 1000)
+
+    assert_includes checks_for(post), :cover_oversized
+  end
+
+  test "히어로 표시 폭보다 좁은 표지를 잡는다" do
+    post = create_post(title: "Undersized Cover")
+    attach_cover(post, width: ContentAudit::COVER_MIN_WIDTH - 1, height: 800)
+
+    assert_includes checks_for(post), :cover_undersized
+  end
+
+  test "표시 폭과 최대 srcset 폭 사이의 표지는 통과한다" do
+    post = create_post(title: "Right Sized Cover")
+    attach_cover(post, width: 1440, height: 960)
+
+    found = checks_for(post)
+    assert_not_includes found, :cover_oversized
+    assert_not_includes found, :cover_undersized
+  end
+
+  # 용량은 더 이상 보지 않는다. 원본이 서빙되지 않으므로 독자에게 닿는 비용이
+  # 아니고, 임계값을 500KB 로 두었을 때 표지 28장이 전부 걸려 신호가 되지 못했다.
+  test "폭이 적당하면 원본이 커도 지적하지 않는다" do
+    post = create_post(title: "Heavy But Right Sized")
+    attach_cover(post, width: 1600, height: 1067, byte_size: 12.megabytes)
+
+    assert_empty checks_for(post).select { |c| c.to_s.start_with?("cover_") }
   end
 
   test "심각도가 error 와 warning 으로 나뉜다" do


### PR DESCRIPTION
## 배경

`ContentAudit` 의 표지 검사가 `byte_size` 를 500KB 기준으로 보고 있었는데, 프로덕션에서 돌리면 **표지 28장이 전부** 걸렸습니다. 전부 걸리는 검사는 신호가 아니라 소음입니다.

그리고 애초에 잘못된 것을 재고 있었습니다. 표지를 그리는 뷰가 전부 `ImageHelper` (`responsive_image_tag` / `optimized_image_tag`) 를 거치므로 **원본 PNG 는 독자에게 전송되지 않습니다.** 나가는 것은 항상 WebP variant 입니다. 원본의 파일 크기는 독자 비용이 아닙니다.

```
볼륨       2.9G 중 132M 사용 (5%)
표지 첨부  28건 / 원본 합계 46.73 MB
```

용량도 문제가 아닙니다.

## 무엇을 대신 보는가

원본이 실제로 결정하는 것은 variant 를 제대로 만들 수 있느냐입니다. srcset 양 끝이 기준이 됩니다.

| 상수 | 값 | 근거 |
|---|---|---|
| `COVER_MAX_WIDTH` | 1920 | `responsive_image_tag` 의 가장 큰 srcset 폭. 초과분은 어떤 variant 로도 쓰이지 않으면서 variant 를 만들 때마다 디코딩 비용만 더한다 |
| `COVER_MIN_WIDTH` | 1024 | 상세 페이지 히어로의 표시 폭(`sizes`). `resize_to_limit` 은 확대하지 않으므로 이보다 좁으면 LCP 이미지가 그대로 흐리게 나간다 |

`cover_too_large` (bytes) → `cover_oversized` / `cover_undersized` (width) 로 교체했습니다.

치수는 blob 이 분석된 뒤에만 존재하므로, 미분석 표지는 짐작하지 않고 치수 검사를 건너뜁니다 — `ImageHelper#intrinsic_dimensions` 가 같은 상황에서 width/height 를 생략하는 것과 같은 이유입니다.

## 실제 데이터

이 기준으로 보면 현재 표지 8종 중:

- `ai_thumbnail.png` 2848px → `cover_oversized` (2글)
- `cs_thumbnail.png` 992px → `cover_undersized` (**10글**, 가장 많이 쓰이는 표지)
- `new_blog_thumbnail.png` 992px → `cover_undersized`

`cs_thumbnail.png` 는 히어로 슬롯(1024px)보다 좁아서 10개 글의 LCP 이미지가 확대 없이 흐리게 나가고 있었습니다. 바이트 기준으로는 절대 보이지 않던 문제입니다.

## 검증

- `content_audit_test.rb` 24 runs / 63 assertions / 0 failures — 새 검사 4건 추가 (초과 / 미달 / 정상 범위 / "폭이 맞으면 12MB 원본도 지적하지 않는다")
- 픽스처가 48x25 라 실제 분석으로는 원하는 폭을 못 만들어, `attach_cover` 헬퍼가 분석 결과만 바꿔 끼웁니다
- RuboCop 무결점 / Brakeman 무경고

🤖 Generated with [Claude Code](https://claude.com/claude-code)