### PR TITLE
fix: 조건부 GET 에서 목록이 두 번 렌더되어 500 이 나던 문제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@
 
 # Personal Files
 /personal/*
-/docs/*
 
 # SimpleCov 커버리지 산출물
 /coverage/
@@ -53,6 +52,12 @@
 
 # 콘텐츠 검토 보고서 — 문서 자체가 "용도: 로컬 참고용" 으로 못박고 있다.
 /BLOG_CONTENT_REVIEW.md
+
+# 야네우라오 뉴스레터 (로컬 참고용). 58편 중 전체 공개는 2026/0715.md 한 편뿐이고
+# 나머지 57편은 "いつもやねうら王をサポートしてくださっている皆さん" 으로 시작하는
+# 지원자 배포 자료다. 이 저장소는 public 이라, 커밋하면 회원 한정 자료를 재배포하게 된다.
+# 글을 쓸 때 인용할 것은 이 파일들이 아니라 여기서 찾아낸 공개 블로그 글(yaneuraou.yaneu.com)이다.
+/docs/yaneuraou/
 
 # Understand-Anything 지식 그래프
 # knowledge-graph.json 등 본체는 커밋한다 — 한 번 올려두면 다른 환경에서

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 # check=error=true
 
-# This Dockerfile is designed for production, not development. Use with Kamal or build'n'run by hand:
+# This Dockerfile is designed for production, not development. Deployed with `fly deploy`,
+# or build'n'run by hand:
 # docker build -t blog_with_rails .
-# docker run -d -p 80:80 -e RAILS_MASTER_KEY=<value from config/master.key> --name blog_with_rails blog_with_rails
+# docker run -d -p 8080:8080 -e RAILS_MASTER_KEY=<value from config/master.key> --name blog_with_rails blog_with_rails
 
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 
@@ -73,6 +74,11 @@ RUN chmod +x /rails/bin/thrust
 # Entrypoint prepares the database.
 ENTRYPOINT ["/rails/bin/docker-entrypoint"]
 
+# Thruster defaults to port 80, which this image cannot bind: it runs as UID 1000 and 80 is
+# privileged. Pin the default here so the image is runnable on its own; fly.toml sets the same
+# value in [env] and must keep matching internal_port.
+ENV HTTP_PORT="8080"
+
 # Start server via Thruster by default, this can be overwritten at runtime
-EXPOSE 80
+EXPOSE 8080
 CMD ["./bin/thrust", "./bin/rails", "server"]

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,7 +24,12 @@ class PostsController < ApplicationController
       # last_modified 는 함께 보내지 않는다. 두 검증자를 모두 주면 둘 다 일치해야
       # 304 가 되는데, 페이지네이션된 relation 의 maximum(:updated_at)은 LIMIT/OFFSET
       # 때문에 2페이지부터 nil 이라 헤더가 빠진다.
-      fresh_when etag: [ @posts.cache_version, params[:category], params[:page] ]
+      #
+      # fresh_when 이 아니라 stale? 을 쓰는 이유는 아래 render 때문이다. 둘 다 신선하면
+      # 304 를 렌더하지만 액션을 중단하지는 않는다. category/page 가 붙은 요청은 그
+      # 뒤에서 show_all 을 한 번 더 렌더하게 되어 DoubleRenderError 로 500 이 났다.
+      # 파라미터 없는 /posts 는 두 번째 렌더가 없어 멀쩡했고, 그래서 오래 눈에 띄지 않았다.
+      return unless stale?(etag: [ @posts.cache_version, params[:category], params[:page] ])
     end
 
     # 페이지 파라미터가 있거나(1페이지 포함) 카테고리가 있으면 show_all 레이아웃으로 표시

--- a/fly.toml
+++ b/fly.toml
@@ -23,6 +23,18 @@ primary_region = "nrt"          # 도쿄. `fly platform regions` 로 현재 목�
   # 특권 포트 바인딩을 피하기 위해 8080으로 올린다. internal_port 와 반드시 일치시킬 것.
   HTTP_PORT = "8080"
 
+  # config/puma.rb 의 기본값은 4다. 이 머신은 vCPU 1개 / 메모리 1GB / 스왑 0 이고,
+  # Active Storage 는 variant 가 없는 이미지를 요청받으면 그 웹 요청 안에서 libvips 를
+  # 돌린다. 즉 워커 수가 곧 libvips 동시 실행 수이자 메모리 피크가 된다.
+  # 2026-08-09, 새 표지를 올린 직후 워커 4개가 동시에 variant 를 만들다 여유 메모리
+  # (333MB)를 소진해 셋이 60초 하트비트를 놓쳤고, Puma 가 이들을 죽이면서 사이트가
+  # 503 이 되었다. 한 요청은 큐에서 470초를 기다린 뒤 502 로 끝났다.
+  WEB_CONCURRENCY = "2"
+
+  # libvips 는 기본적으로 코어 수만큼 스레드를 띄운다. vCPU 가 1개이므로 이득은 없고
+  # 메모리만 더 쓴다.
+  VIPS_CONCURRENCY = "1"
+
   ALLOWED_HOSTS = "www.kamillee0918.blog,kamillee0918.blog,kamillee0918-blog.fly.dev"
   APP_HOST = "kamillee0918.blog"
 
@@ -57,4 +69,9 @@ primary_region = "nrt"          # 도쿄. `fly platform regions` 로 현재 목�
 
 [[vm]]
   size = "shared-cpu-1x"
-  memory = "1gb"              # libvips 이미지 변환이 있어 512MB 는 빠듯하다
+  # 512MB → 1GB → 2GB. libvips 이미지 변환 때문에 계속 올렸다.
+  # 1GB 로도 부족했던 이유는 Active Storage 가 variant 를 웹 요청 안에서 만들기 때문이다.
+  # 표지 한 장을 바꾸면 아직 없는 variant 를 방문자가 요청하는 대로 그 자리에서 생성하는데,
+  # 유휴 상태에서 이미 605MB 를 쓰고 있어 여유가 333MB 뿐이었고 스왑은 0 이라 완충이 없었다.
+  # 2026-08-09 에 이것이 워커 정지 → Puma 60초 타임아웃 → 503 으로 이어졌다(WEB_CONCURRENCY 주석 참고).
+  memory = "2gb"

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -84,6 +84,48 @@ class PostsControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_modified
   end
 
+  # 위 테스트는 파라미터 없는 /posts 만 본다. 그 경로는 show_all 을 렌더하지 않아
+  # 두 번째 렌더가 일어나지 않고, 그래서 아래 버그를 놓쳤다.
+  # fresh_when 은 304 를 렌더하지만 액션을 중단하지 않는다. category/page 가 붙으면
+  # 그 뒤의 render :show_all 이 두 번째 렌더가 되어 DoubleRenderError → 500 이 된다.
+  # 즉 카테고리 페이지와 페이지네이션은 재방문자에게 전부 500 이었다.
+  test "category listing answers 304 instead of raising DoubleRenderError" do
+    delete logout_url
+    get posts_url(category: posts(:one).category)
+
+    get posts_url(category: posts(:one).category)
+    assert_response :success
+    etag = response.headers["ETag"]
+    assert_not_nil etag, "ETag 헤더가 없다"
+
+    get posts_url(category: posts(:one).category), headers: { "If-None-Match" => etag }
+    assert_response :not_modified
+  end
+
+  test "paginated listing answers 304 instead of raising DoubleRenderError" do
+    delete logout_url
+    get posts_url(page: 1)
+
+    get posts_url(page: 1)
+    assert_response :success
+    etag = response.headers["ETag"]
+    assert_not_nil etag, "ETag 헤더가 없다"
+
+    get posts_url(page: 1), headers: { "If-None-Match" => etag }
+    assert_response :not_modified
+  end
+
+  # 304 로 끊더라도 신선하지 않은 요청은 계속 목록을 렌더해야 한다.
+  # assert_template 은 rails-controller-testing 젬이 있어야 쓸 수 있는데 이 앱에는 없다.
+  # 대신 본문에 해당 카테고리 글이 실려 나오는지로 확인한다.
+  test "category listing still renders the listing when the ETag does not match" do
+    delete logout_url
+    get posts_url(category: posts(:one).category), headers: { "If-None-Match" => "W/\"stale\"" }
+
+    assert_response :success
+    assert_match posts(:one).title, response.body
+  end
+
   test "index ETag changes once a post is edited" do
     delete logout_url
     get posts_url


### PR DESCRIPTION
## 문제

카테고리 페이지와 페이지네이션이 **재방문자에게 전부 500** 이었습니다. 프로덕션 실측:

```
/posts?category=CS   + If-None-Match  →  500
/posts?page=1        + If-None-Match  →  500
/posts (파라미터 없음) + If-None-Match  →  304 ✅
```

`AbstractController::DoubleRenderError` 입니다. `fresh_when` 은 304 를 렌더하지만 액션을 중단하지 않아서, `category`/`page` 가 붙은 요청은 그 뒤의 `render :show_all` 이 두 번째 렌더가 됩니다.

파라미터 없는 `/posts` 는 그 분기를 타지 않아 멀쩡했고, **기존 304 테스트가 정확히 그 경로만 검증**하고 있어서 오래 눈에 띄지 않았습니다.

## 수정

`stale?` 로 바꿔 신선하면 명시적으로 `return` 합니다.

## 테스트

실패를 먼저 재현하고 고쳤습니다.

- `category listing answers 304 instead of raising DoubleRenderError`
- `paginated listing answers 304 instead of raising DoubleRenderError`
- `category listing still renders the listing when the ETag does not match` — 304 로 끊더라도 신선하지 않은 요청은 계속 렌더해야 함

`bin/check-code` 통과 (113 runs / 272 assertions / 0 failures).

## 함께 담긴 것

2026-08-09 의 503 장애 대응입니다. 이미 프로덕션에 배포되어 있고, 저장소가 그 상태를 따라가지 못하고 있어 함께 커밋했습니다.

- `WEB_CONCURRENCY=2` / `VIPS_CONCURRENCY=1` / 메모리 2GB — 워커 4개가 각자 libvips 를 돌려 여유 메모리(333MB)를 소진, 워커 3개가 60초 하트비트를 놓쳐 Puma 가 종료, 한 요청은 큐에서 470초 대기 후 502
- `EXPOSE 80` → `8080` + `ENV HTTP_PORT` — UID 1000 으로 도는 이미지는 80 을 바인딩할 수 없어 선언이 사실과 달랐음
- `.gitignore` 에 `/docs/yaneuraou/` — 58편 중 57편이 지원자 배포 자료인데 이 저장소는 public

🤖 Generated with [Claude Code](https://claude.com/claude-code)